### PR TITLE
chore: Chose any icon for knobs

### DIFF
--- a/src/Icon/Icon.stories.tsx
+++ b/src/Icon/Icon.stories.tsx
@@ -46,8 +46,8 @@ storiesOf('Components/Icon', module)
     ))
     .add('Size & Color', () => {
         const iconKey = select('Select an Icon', Object.keys(Icon), 'AddEvent');
-        console.log(iconKey);
-        return(
+
+        return (
             <StyledStory>
                 {React.createElement(Icon[iconKey], {
                     color: color('color', DefaultColor),
@@ -55,7 +55,7 @@ storiesOf('Components/Icon', module)
                         'scale',
                         ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'],
                         'md'
-                    )
+                    ),
                 })}
             </StyledStory>
         );

--- a/src/Icon/Icon.stories.tsx
+++ b/src/Icon/Icon.stories.tsx
@@ -44,15 +44,19 @@ storiesOf('Components/Icon', module)
             </Grid>
         </StyledStory>
     ))
-    .add('Size & Color', () => (
-        <StyledStory>
-            <Icon.AddEvent
-                color={color('color', DefaultColor)}
-                scale={select(
-                    'scale',
-                    ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'],
-                    'md'
-                )}
-            />
-        </StyledStory>
-    ));
+    .add('Size & Color', () => {
+        const iconKey = select('Select an Icon', Object.keys(Icon), 'AddEvent');
+        console.log(iconKey);
+        return(
+            <StyledStory>
+                {React.createElement(Icon[iconKey], {
+                    color: color('color', DefaultColor),
+                    scale: select(
+                        'scale',
+                        ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'],
+                        'md'
+                    )
+                })}
+            </StyledStory>
+        );
+    });


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.

---------
**Outline your feature or bug-fix below**

In Storybook, under Icons > Sizes & Colors, the user can now select any icon to apply colors and scale to.
