### PR TITLE
fix: TypeScript + Rollup + export problems

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,8 @@
         [
             "@babel/preset-env",
             {
-                "useBuiltIns": "entry"
+                "useBuiltIns": "entry",
+                "corejs": "core-js@3"
             }
         ]
     ]

--- a/src/Button/index.ts
+++ b/src/Button/index.ts
@@ -1,1 +1,3 @@
-export { Button, ButtonProps } from './Button.component';
+// Button and ButtonProps will be exported.
+// Using the wildcard because Babel has difficulty interpreting TypeScript interfaces when they are re-exported
+export * from './Button.component';

--- a/src/Icon/index.ts
+++ b/src/Icon/index.ts
@@ -1,4 +1,7 @@
-export { AnchorIcons } from './utils';
+// When re-exporting an interface its type must be explicitly defined
+import { AnchorIcons } from './utils';
+export type AnchorIcons = AnchorIcons;
+
 export { AddEvent } from './Icons/AddEvent.component';
 export { ArrowBack } from './Icons/ArrowBack.component';
 export { ArrowForward } from './Icons/ArrowForward.component';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,8 @@
-export { colors, Color } from './colors.theme';
+// When re-exporting an interface its type must be explicitly defined
+import { Color } from './colors.theme';
+export type Color = Color;
+
+export { colors } from './colors.theme';
 export { fonts } from './fonts.theme';
 export { sizes } from './sizes.theme';
 export { variables } from './variables.theme';


### PR DESCRIPTION
TypeScript + Rollup have an issue when re-exporting Typescript Interface's and Type's.
In the case of Type's, the re-export must explictly be set to Type.
In the case of Interface's, used the wildcard (*).

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components

---------
**Outline your feature or bug-fix below**

The build process would fail because of the re-exporting of Interface's and Type's from the theme, button and icon components. After much digging I found ways to make the re-export still work and pass the build process.
