### PR TITLE
fix: Collapse listed in exports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ I have done **all** of the following:
 - [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
 - [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
 - [ ] Added name to OWNERS file for all new components
+- [ ] If adding a new component, add its export to the rollup config
 
 ---------
 **Outline your feature or bug-fix below**

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,7 @@ const componentList = {
     badge: './src/Badge/index.ts',
     button: './src/Button/index.ts',
     card: './src/Card/index.ts',
+    collapse: './src/Collapse/index.ts',
     dropdown: './src/DropDown/index.ts',
     form: './src/Form/index.ts',
     grid: './src/Grid/index.ts',


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components

---------
**Outline your feature or bug-fix below**

The Collapse/CollapseGroup component(s) were not listed among the exports in the rollup config. As such the entire component was included with all other components. This fix will correctly put the component(s) into its own file rather than into index.js.

This will require an upgrade to version .30 as anyone using Anchor will be importing Collapse whether they want to or not.
