### PR TITLE
fix: No longer need window.location for sidenav 

### DIFF
--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -9,7 +9,7 @@ import styled, { ThemeProvider } from '@xstyled/styled-components';
 import { fonts, NormalizeCSS } from '../../../../../src/theme';
 import { RootTheme } from '../../../../../src/theme';
 import { Footer } from '../';
-import { SideNavigation } from '../../Navigation';
+import { EnhancedSideNavigation } from '../../Navigation';
 import { CodePreview } from '../../CodePreview';
 import {
     Grid,
@@ -251,7 +251,7 @@ export const Page = ({
                 <Grid columns="minmax(180px, 300px) 1fr">
                     <StyledSideNav>
                         <div>
-                            <SideNavigation />
+                            <EnhancedSideNavigation />
                         </div>
                     </StyledSideNav>
                     <Cell>

--- a/docs/src/components/Navigation/AddLocation.tsx
+++ b/docs/src/components/Navigation/AddLocation.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Location } from '@reach/router';
+
+// Gatsby now uses @reach/router which makes it so that not every component has access to the location
+// prop like it used to in Gatsby 1.x. This HOC adds that prop to the component passed to it.
+export function AddLocation(Component: any) {
+    return class EnhancedWithLocation extends React.Component {
+        render() {
+            return(
+                <Location>
+                    {locationProps => <Component {...locationProps} {...this.props} />}
+                </Location>
+            );
+        }
+    };
+}

--- a/docs/src/components/Navigation/SideNavigation/SideNavigation.component.tsx
+++ b/docs/src/components/Navigation/SideNavigation/SideNavigation.component.tsx
@@ -42,16 +42,13 @@ class SideNavigation extends React.PureComponent<SideNavigationProps> {
     };
 
     componentWillMount() {
-        let mainOpenIndex = 0;
+        const { pathname } = this.props.location;
 
-        sections.forEach((section: SectionProperties, i: number) => {
+        const mainOpenIndex = sections.reduce((openIndex: number, section: SectionProperties, index: number) => {
             const { pattern } = section;
-            const { pathname } = this.props.location;
             // Compares the current url with the path associated to a section and gets its index if it matches.
-            if (pattern.length && pathname.includes(pattern)) {
-                mainOpenIndex = i;
-            }
-        });
+            return (pattern.length && pathname.includes(pattern)) ? index : openIndex;
+          }, 0);
 
         this.setState({mainOpenIndex});
     }

--- a/docs/src/components/Navigation/SideNavigation/SideNavigation.component.tsx
+++ b/docs/src/components/Navigation/SideNavigation/SideNavigation.component.tsx
@@ -7,6 +7,7 @@ import styled from '@xstyled/styled-components';
 import { Collapse, CollapseGroup } from '@retailmenot/anchor';
 // TODO: Change the config to allow ts extensions. This works, but tsconfig is having a snit.
 import { sections } from './sections';
+import { AddLocation } from '../AddLocation';
 
 const StyledCollapseGroup = styled(CollapseGroup)`
     li a {
@@ -20,6 +21,10 @@ const StyledCollapseGroup = styled(CollapseGroup)`
     }
 `;
 
+interface SideNavigationProps {
+    location?: object;
+}
+
 interface SectionProperties {
     title: string;
     pattern: string;
@@ -31,32 +36,33 @@ interface LinkProperties {
     path: string;
 }
 
-export class SideNavigation extends React.PureComponent {
-    mainOpenIndex: number;
+class SideNavigation extends React.PureComponent<SideNavigationProps> {
+    state = {
+        mainOpenIndex: false,
+    };
 
-    // I'm using PureComponent in order to use a constructor since ComponentWillMount is being deprecated.
-    // I need to get the index of the current section in order to pass that value to CollapseGroup.
-    // This is what makes the correct Collapse component open when navigating the site.
-    constructor(props: object) {
-        super(props);
-    }
+    componentWillMount() {
+        let mainOpenIndex = 0;
 
-    componentDidMount(): void {
         sections.forEach((section: SectionProperties, i: number) => {
             const { pattern } = section;
-            const { pathname } = window.location;
+            const { pathname } = this.props.location;
             // Compares the current url with the path associated to a section and gets its index if it matches.
-            if (pattern.length > 0 && pathname.includes(pattern)) {
-                this.mainOpenIndex = i;
+            if (pattern.length && pathname.includes(pattern)) {
+                mainOpenIndex = i;
             }
         });
+
+        this.setState({mainOpenIndex});
     }
 
     render() {
-        return (
+        const { mainOpenIndex } = this.state;
+
+        return ( mainOpenIndex !== false && (
             <StyledCollapseGroup
-                theme="compact"
-                openIndex={this.mainOpenIndex}
+                variant="compact"
+                openIndex={mainOpenIndex}
                 accordion
             >
                 {sections.map((section: SectionProperties, i: number) => (
@@ -80,7 +86,10 @@ export class SideNavigation extends React.PureComponent {
                         </ul>
                     </Collapse>
                 ))}
-            </StyledCollapseGroup>
+            </StyledCollapseGroup>)
         );
     }
 }
+
+// HOC adds the location prop to SideNavigation
+export const EnhancedSideNavigation = AddLocation(SideNavigation);

--- a/docs/src/components/Navigation/SideNavigation/sections.ts
+++ b/docs/src/components/Navigation/SideNavigation/sections.ts
@@ -16,67 +16,67 @@ export const sections = [
         links: [
             {
                 title: 'All',
-                path: '/components',
+                path: '/components/',
             },
             {
                 title: 'Autocomplete',
-                path: '/components/autocomplete',
+                path: '/components/autocomplete/',
             },
             {
                 title: 'Badge',
-                path: '/components/badge',
+                path: '/components/badge/',
             },
             {
                 title: 'Button',
-                path: '/components/button',
+                path: '/components/button/',
             },
             {
                 title: 'Card',
-                path: '/components/card',
+                path: '/components/card/',
             },
             {
                 title: 'Collapse',
-                path: '/components/collapse/',
+                path: '/components/collapse//',
             },
             {
                 title: 'Dropdown',
-                path: '/components/dropdown',
+                path: '/components/dropdown/',
             },
             {
                 title: 'Grid',
-                path: '/components/grid',
+                path: '/components/grid/',
             },
             {
                 title: 'Hero',
-                path: '/components/hero',
+                path: '/components/hero/',
             },
             {
                 title: 'Icon',
-                path: '/components/icon',
+                path: '/components/icon/',
             },
             {
                 title: 'Input',
-                path: '/components/input',
+                path: '/components/input/',
             },
             {
                 title: 'Layout',
-                path: '/components/layout',
+                path: '/components/layout/',
             },
             {
                 title: 'List',
-                path: '/components/list',
+                path: '/components/list/',
             },
             {
                 title: 'Menu',
-                path: '/components/menu',
+                path: '/components/menu/',
             },
             {
                 title: 'Modal',
-                path: '/components/modal',
+                path: '/components/modal/',
             },
             {
                 title: 'Typography',
-                path: '/components/typography',
+                path: '/components/typography/',
             },
         ],
     },
@@ -87,7 +87,7 @@ export const sections = [
         links: [
             {
                 title: 'RMN',
-                path: '/theme',
+                path: '/theme/',
             },
         ],
     },
@@ -98,7 +98,7 @@ export const sections = [
         links: [
             {
                 title: '[In Development]',
-                path: '/utilities',
+                path: '/utilities/',
             },
         ],
     },

--- a/docs/src/components/Navigation/index.ts
+++ b/docs/src/components/Navigation/index.ts
@@ -1,2 +1,2 @@
 export { NavigationBar } from './NavigationBar/NavigationBar.component';
-export { SideNavigation } from './SideNavigation/SideNavigation.component';
+export { EnhancedSideNavigation } from './SideNavigation/SideNavigation.component';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "0.0.1-alpha.35",
+  "version": "0.0.1-alpha.36",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/Button/__snapshots__/Button.spec.tsx.snap
@@ -4068,6 +4068,7 @@ exports[`Component: Button Theme Provided should use custom size variants from t
   background-color: #0998D6;
   color: #FFFFFF;
   padding: 0 4rem;
+  font-size: 0;
   height: 8rem;
   min-width: 30rem;
 }


### PR DESCRIPTION
feat: New HOC, AddLocation. Gives any component access to the router's location prop

fix: Using ^, no longer have to use window.location which was making the build fail

fix: updated all paths so that activeClassName correctly is fired for sidenav

chore: Moved logic from constructor into componentDidMount

chore: prettier updates

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config

---------
**Outline your feature or bug-fix below**

This should take care of two issues. 1) No longer need to access window.location from the SideNavigation component. That's good because it was causing the build to fail.  2) No longer have the initialization code in the constructor, it can exist within the componentDidMount lifecycle method.
