### PR TITLE
feat: Add Collapse/CollapseGroup documentation to doc site

### DIFF
--- a/docs/src/components/CodePreview/CodePreview.component.tsx
+++ b/docs/src/components/CodePreview/CodePreview.component.tsx
@@ -11,7 +11,11 @@ import {
     LiveError,
 } from 'react-live';
 import Component from '@reach/component-component';
-import { AutoComplete } from '@retailmenot/anchor';
+import {
+    AutoComplete,
+    Collapse,
+    CollapseGroup
+} from '@retailmenot/anchor';
 // COMPONENTS
 import * as Anchor from '../../../../src';
 // THEME
@@ -107,6 +111,8 @@ const scope = {
     Component,
     // Overrides
     AutoComplete,
+    Collapse,
+    CollapseGroup,
 };
 
 export const CodePreview = ({
@@ -114,8 +120,8 @@ export const CodePreview = ({
 }: CodePreviewProps): React.ReactElement<any> => (
     <StyledContainerElement>
         <LiveProvider code={children} scope={scope}>
-            <StyledLivePreview />
             <StyledLiveEditor wrap="true" />
+            <StyledLivePreview />
             <StyledErrorElement />
         </LiveProvider>
     </StyledContainerElement>

--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -117,13 +117,23 @@ const StyledPrimaryNav = styled.nav`
     }
 `;
 
+// These are standard markdown styles for an inlineCode block. Can't use 'code' because that is tied
+// to the CodePreview component.
+const StyledInlineCode = styled.span`
+    background-color: rgba(27,31,35,.05);
+    font-family: "SFMono-Regular",Consolas,Liberation Mono,Menlo,Courier,monospace;
+    border-radius: 3px;
+    padding: .2em .4em;
+    font-size: 85%;
+`;
+
 const StyledTable = styled.table``;
 
 const Components: any = {};
 
 Components.code = (props: any) => <CodePreview {...props} />;
 Components.wrapper = (props: any) => <React.Fragment {...props} />;
-Components.inlineCode = (props: any) => <Typography tag="code" {...props} />;
+Components.inlineCode = (props: any) => <StyledInlineCode {...props} />;
 Components.pre = (props: any) => <Typography tag="pre" {...props} />;
 Components.h1 = ({ children, ...props }: any) => (
     <Typography
@@ -181,6 +191,7 @@ Components.h6 = ({ children, ...props }: any) => (
         children={children}
     />
 );
+
 Components.p = (props: any) => <Typography tag="p" {...props} />;
 Components.a = (props: any) => (
     <Typography color={colors.flashPink.base} tag="a" {...props} />

--- a/docs/src/pages/components/collapse.mdx
+++ b/docs/src/pages/components/collapse.mdx
@@ -1,2 +1,80 @@
 # Collapse
 
+The Collapse component allows a user to click on a button and toggle the rendering of its child.
+
+### Usage
+
+```tsx
+<Collapse>
+    I will appear and disappear when the rendered button is clicked!
+</Collapse>
+```
+
+<br />
+
+### Settings/Props
+
+The component can accept the following `props`:
+
+* `isOpen` *(boolean)*: Defaults to **`false`**. Determines whether the Collapse component is open or not. Changing the value of this prop will programatticaly open/close the component, thusly not requiring a click event.
+
+* `openedText` *(string)*: Defaults to **`'Close'`**. The text that appears on the button as a Call To Action (CTA) when the component is open. If this prop is used and the `closedText` prop is not, `closedText` will use whatever is defined for `openedText`. This is useful if you don't actually want the CTA text to change.
+
+* `closedText` *(string)*: Defaults to **`'Open'`**. The text that appears on the button as a CTA when the component is closed.
+
+* `openedIcon` *(React.ReactElement)*: Defaults to **`<ChevronDown />`** from `Icon`. Accepts any component to render, although realistically sticking to components from `Icon` make the most sense.
+
+* `closedIcon` *(React.ReactElement)*: Defaults to **`<ChevronUp />`** from `Icon`. Accepts any component to render, although realistically sticking to components from `Icon` make the most sense.
+
+#### openedIcon and/or closedIcon usage
+
+```tsx
+<Collapse
+    openedIcon={<ArrowBack />}
+    closedIcon={<ArrowForward />}
+>
+    <div>Hello world.</div>
+</Collapse>
+```
+
+* `variant` *('comfortable' | 'compact' | 'none')*: Defaults to **`'comfortable'`**.
+    * **comfortable**: has considerable spacing. It is intended to be used for showing/hiding larger pieces of content.
+    * **compact**: has much tighter spacing. It is intended to be used for showing/hiding navigation elements.
+    * **none**: Applies no styling whatsoever to the component. Useful for when you want complete control of all styling via styled-components/css/etc., but still keep the functionality of the component. The component has many classes in place to try and make it easier to accomplish this.
+
+* `hasBottomBorder`: *(boolean)*: Defaults to **`true`**. Shows/hides the bottom border.
+
+<br /><br />
+
+# CollapseGroup
+
+The **`CollapseGroup`** component combines multiple **`Collapse`** components together, allowing a single component to apply props to all children, unifying their appearance, and adding the ability to have accordion functionality.
+
+### Usage
+
+```tsx
+<CollapseGroup variant="compact">
+    <Collapse>
+        I will appear and disappear when the rendered button is clicked!
+    </Collapse>
+    <Collapse>
+        I will also appear and disappear when the rendered button is clicked!
+    </Collapse>
+</CollapseGroup>
+```
+
+### Settings/Props
+
+The component can accept the following `props`:
+
+* `openedIcon` *(React.ReactElement)*: No default. Using this prop will apply the setting to all child **`Collapse`** components. Otherwise its functionality is as noted above for **`Collapse`**.
+
+* `closedIcon` *(React.ReactElement)*: No default. Using this prop will apply the setting to all child **`Collapse`** components. Otherwise its functionality is as noted above for **`Collapse`**.
+
+* `variant` *('comfortable' | 'compact' | 'none')*: No default. Using this prop will apply the setting to all child **`Collapse`** components. Otherwise its functionality is as noted above for **`Collapse`**.
+
+* `accordion` *(boolean)*: Defaults to **`false`**. Enables accordion functionality, where only one **`Collapse`** component can be open at a time.
+
+* `openIndex` *(number)*: Defaults to **`0`**. If **`accordion`** is set to **`true`**, this determines which **`Collapse`** component will start in the open state.
+
+<br /><br />

--- a/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
+++ b/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
@@ -27,19 +27,6 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
   background-color: #F1F1F1;
 }
 
-.c1 span.anchor-typography {
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.c1 ~ .anchor-list-divider {
-  padding-top: 0.25rem;
-}
-
-.c1 ~ .anchor-list-title {
-  margin-top: 0.5rem;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -212,19 +199,6 @@ exports[`Component: ResultsContainer should be defined 1`] = `
   background-color: #F1F1F1;
 }
 
-.c2 span.anchor-typography {
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.c2 ~ .anchor-list-divider {
-  padding-top: 0.25rem;
-}
-
-.c2 ~ .anchor-list-title {
-  margin-top: 0.5rem;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -290,6 +264,7 @@ exports[`Component: ResultsContainer should be defined 1`] = `
 
 .c1 {
   box-sizing: border-box;
+  padding-bottom: 1.25rem;
 }
 
 .c0 {

--- a/src/Icon/Icon.component.spec.tsx
+++ b/src/Icon/Icon.component.spec.tsx
@@ -1,7 +1,10 @@
 // REACT
+import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { shallow } from 'enzyme'
 // COMPONENT
 import * as Icon from './';
+// import { AddEvent } from './Icons/AddEvent.component';
 
 describe('Component: Icon', () => {
     Object.keys(Icon).forEach((key: string) => {
@@ -9,6 +12,15 @@ describe('Component: Icon', () => {
             const subject = Icon[key]({});
             const tree = renderer.create(subject).toJSON();
             expect(tree).toMatchSnapshot();
+        });
+    });
+
+    Object.keys(Icon).forEach((key: string) => {
+        it(`should scale`, () => {
+            const subject = React.createElement(Icon[key], {scale: 'lg'});
+            const component = shallow(subject);
+
+            expect( component.find('svg').find({ width: 24, height: 24 }).exists() ).toBeTruthy();
         });
     });
 });

--- a/src/Icon/Icon.component.spec.tsx
+++ b/src/Icon/Icon.component.spec.tsx
@@ -1,7 +1,7 @@
 // REACT
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import { shallow } from 'enzyme'
+import { shallow } from 'enzyme';
 // COMPONENT
 import * as Icon from './';
 // import { AddEvent } from './Icons/AddEvent.component';
@@ -17,10 +17,15 @@ describe('Component: Icon', () => {
 
     Object.keys(Icon).forEach((key: string) => {
         it(`should scale`, () => {
-            const subject = React.createElement(Icon[key], {scale: 'lg'});
+            const subject = React.createElement(Icon[key], { scale: 'lg' });
             const component = shallow(subject);
 
-            expect( component.find('svg').find({ width: 24, height: 24 }).exists() ).toBeTruthy();
+            expect(
+                component
+                    .find('svg')
+                    .find({ width: 24, height: 24 })
+                    .exists()
+            ).toBeTruthy();
         });
     });
 });

--- a/src/List/Item/Item.component.tsx
+++ b/src/List/Item/Item.component.tsx
@@ -39,19 +39,6 @@ const StyledItem = styled('a')<ItemProps>`
     &.active {
         background-color: neutrals.silver.base;
     }
-
-    span.anchor-typography {
-        ${({ size = 'sm' }) =>
-            size === 'sm'
-                ? css({ fontSize: '0.875rem', fontWeight: 500 })
-                : css({ fontSize: '1rem', fontWeight: 400 })}
-    }
-    ~ .anchor-list-divider {
-        padding-top: 0.25rem;
-    }
-    ~ .anchor-list-title {
-        margin-top: 0.5rem;
-    }
 `;
 
 const StyledTypography = styled(Typography)`
@@ -60,7 +47,6 @@ const StyledTypography = styled(Typography)`
     align-items: center;
     width: 100%;
     height: 100%;
-
     .item-prefix {
         display: flex;
         align-items: center;

--- a/src/List/Item/Item.component.tsx
+++ b/src/List/Item/Item.component.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
-import styled, { css } from '@xstyled/styled-components';
+import styled from '@xstyled/styled-components';
 // COMPONENTS
 import { Typography } from '../../Typography';
 

--- a/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
+++ b/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
@@ -27,19 +27,6 @@ exports[`Component: Item should be defined 1`] = `
   background-color: #F1F1F1;
 }
 
-.c0 span.anchor-typography {
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.c0 ~ .anchor-list-divider {
-  padding-top: 0.25rem;
-}
-
-.c0 ~ .anchor-list-title {
-  margin-top: 0.5rem;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/List/__snapshots__/List.component.spec.tsx.snap
+++ b/src/List/__snapshots__/List.component.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Component: List should be defined 1`] = `
 .c0 {
   box-sizing: border-box;
+  padding-bottom: 1.25rem;
 }
 
 <div

--- a/src/Modal/Close/Close.spec.tsx
+++ b/src/Modal/Close/Close.spec.tsx
@@ -11,4 +11,11 @@ describe('Component: Modal.Close', () => {
         const tree = renderer.create(subject).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    it('should match snapshot with alignment set', () => {
+        const subject = <Close align="left" />;
+        const tree = renderer.create(subject).toJSON();
+
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/src/Modal/Close/__snapshots__/Close.spec.tsx.snap
+++ b/src/Modal/Close/__snapshots__/Close.spec.tsx.snap
@@ -1,5 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: Modal.Close should match snapshot with alignment set 1`] = `
+.c2 {
+  position: relative;
+  border-radius: circular;
+  font-weight: 600;
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  text-align: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  outline: none !important;
+  margin: 0;
+  -webkit-transition: 500ms ease background-color, 500ms ease border-color, 500ms ease color, 500ms ease fill;
+  transition: 500ms ease background-color, 500ms ease border-color, 500ms ease color, 500ms ease fill;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  border: solid thin transparent;
+  background-color: transparent;
+  color: #0074A6;
+  padding: 0;
+  font-size: 1rem;
+  height: 3rem;
+  min-width: 3rem;
+}
+
+.c2 + .c1 {
+  margin-left: 1rem;
+}
+
+.c2:hover,
+.c2:focus,
+.c2:active {
+  background: rgba(128,128,128,0.16);
+  color: #0074A6;
+}
+
+.c3 {
+  display: inline-block;
+  height: 1.5rem;
+  width: 1.5rem;
+  line-height: 0;
+}
+
+.c0 {
+  position: absolute;
+  height: 3rem;
+  width: 3rem;
+  margin: 0.5rem;
+  top: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+}
+
+<div
+  className="anchor-modal-close c0"
+>
+  <button
+    className="anchor-button c1 c2"
+  >
+    <span
+      className="anchor-icon close anchor-button-prefix c3"
+      scale="lg"
+    >
+      <svg
+        height={24}
+        viewBox="0 0 16 16"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+        >
+          <path
+            d="M0 0h16v16H0z"
+          />
+          <g
+            fill="currentColor"
+            fillRule="nonzero"
+          >
+            <path
+              d="M4.398 4.37l6.852 6.85-.495.495-6.852-6.85c-.292-.292-.354-.75-.073-1.032.283-.284.742-.222 1.035.07l6.85 6.851c.293.292.355.75.111.987l-.04.048c-.28.281-.74.218-1.031-.074l.495-.495c.033.034.055.044.036.078-.02.013-.027-.01-.065-.049L4.371 4.4c-.044-.043-.068-.047-.044-.072.025-.024.029 0 .071.043z"
+            />
+            <path
+              d="M11.468 4.617l.248.248-6.851 6.85c-.292.293-.75.355-1.012.092l-.023-.021c-.281-.281-.218-.74.073-1.032l6.85-6.85c.292-.293.752-.355 1.013-.092l.023.021c.281.281.218.74-.073 1.031l-.248-.247z"
+            />
+          </g>
+        </g>
+      </svg>
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Component: Modal.Close should render 1`] = `
 .c2 {
   position: relative;

--- a/src/Modal/Footer/Footer.spec.tsx
+++ b/src/Modal/Footer/Footer.spec.tsx
@@ -1,6 +1,7 @@
 // REACT
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+
 // COMPONENT
 import { Modal } from '..';
 const { Footer } = Modal;
@@ -9,6 +10,14 @@ describe('Component: Modal.Footer', () => {
     it('should render', () => {
         const subject = <Footer>Text</Footer>;
         const tree = renderer.create(subject).toJSON();
+
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('should match snapshot with padding', () => {
+        const subject = <Footer padding="1rem">Text</Footer>;
+        const tree = renderer.create(subject).toJSON();
+
         expect(tree).toMatchSnapshot();
     });
 });

--- a/src/Modal/Footer/__snapshots__/Footer.spec.tsx.snap
+++ b/src/Modal/Footer/__snapshots__/Footer.spec.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: Modal.Footer should match snapshot with padding 1`] = `
+.c0 {
+  box-sizing: border-box;
+  width: 100%;
+  border-radius: 0 0 modal modal;
+  margin-top: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  justify-self: flex-end;
+  background: transparent;
+}
+
+.c0.c0 {
+  padding: 1rem;
+}
+
+<div
+  className="anchor-modal-footer c0"
+>
+  Text
+</div>
+`;
+
 exports[`Component: Modal.Footer should render 1`] = `
 .c0 {
   box-sizing: border-box;

--- a/src/utils/filterChildrenByType/filterChildrenByType.ts
+++ b/src/utils/filterChildrenByType/filterChildrenByType.ts
@@ -10,8 +10,10 @@ export const filterChildrenByType = (
 ): React.ReactChild[] => {
     const goodChildren: React.ReactChild[] = [];
     const acceptedTypes: string[] = Array.isArray(type) ? [...type] : [type];
+
     React.Children.forEach(children, (child: any) => {
         const childType: string = get(child, 'type.displayName', 'unknown');
+
         if (acceptedTypes.includes(childType)) {
             goodChildren.push(child);
         } else {
@@ -25,5 +27,6 @@ export const filterChildrenByType = (
             }
         }
     });
+
     return goodChildren;
 };


### PR DESCRIPTION
feat: Added the documentation for Collapse to the collapse.mdx file

fix: Changed MDXProvider's use of pre to use typography's pre tag, inline display type

fix: Added Collapse and CollapseGroup to scope for CodePreview to avoid incorrect webhook error

feat: Added new styled component to handle inline styles for mdx

chore: Cleaned up collapse.mdx

chore: prettier

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config

---------
**Outline your feature or bug-fix below**

This adds the Collapse/CollapseGroup documentation to the doc site, but with some alterations to take advantage of mdx and the live code editor. This also allows inline code for mdx files.
