### PR TITLE
fix: toggle double onChange, modal border radius and modal exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "0.0.1-beta.5",
+  "version": "0.0.1-beta.6",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Button/Button.spec.tsx
+++ b/src/Button/Button.spec.tsx
@@ -367,6 +367,7 @@ describe('Component: Button', () => {
                             affixSpacing: 3,
                             padding: 4,
                             contentPadding: 5,
+                            fontSize: 1.5,
                         },
                     },
                 },

--- a/src/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/Button/__snapshots__/Button.spec.tsx.snap
@@ -4068,6 +4068,7 @@ exports[`Component: Button Theme Provided should use custom size variants from t
   background-color: #0998D6;
   color: #FFFFFF;
   padding: 0 4rem;
+  font-size: 1.5rem;
   height: 8rem;
   min-width: 30rem;
 }

--- a/src/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/Button/__snapshots__/Button.spec.tsx.snap
@@ -4068,7 +4068,6 @@ exports[`Component: Button Theme Provided should use custom size variants from t
   background-color: #0998D6;
   color: #FFFFFF;
   padding: 0 4rem;
-  font-size: 0;
   height: 8rem;
   min-width: 30rem;
 }

--- a/src/Form/ControlLabel/ControlLabel.component.tsx
+++ b/src/Form/ControlLabel/ControlLabel.component.tsx
@@ -32,7 +32,7 @@ interface ControlLabelProps extends SpaceProps, TypographyProps {
     value?: string;
     label: string;
     name?: string;
-    control: React.ReactElement<any>;
+    control?: React.ReactElement<any>;
     labelPlacement?: 'left' | 'right';
     labelSpacing?: string | number;
 }
@@ -66,13 +66,16 @@ export const ControlLabel = ({
         lineHeight={lineHeight}
         {...props}
     >
-        {cloneWithProps(control, {
-            value,
-            disabled,
-            name,
-            marginLeft: labelPlacement === 'left' ? labelSpacing : undefined,
-            marginRight: labelPlacement === 'right' ? labelSpacing : undefined,
-        })}
+        {control &&
+            cloneWithProps(control, {
+                value,
+                disabled,
+                name,
+                marginLeft:
+                    labelPlacement === 'left' ? labelSpacing : undefined,
+                marginRight:
+                    labelPlacement === 'right' ? labelSpacing : undefined,
+            })}
         {label}
     </StyledLabel>
 );

--- a/src/Form/Toggle/Toggle.component.tsx
+++ b/src/Form/Toggle/Toggle.component.tsx
@@ -139,6 +139,7 @@ export const Toggle = forwardRef(
             trackHeight = '0.75rem',
             trackWidth = '2rem',
             disabled,
+            onChange,
             ...props
         }: ToggleProps,
         ref: React.RefObject<any>
@@ -164,6 +165,7 @@ export const Toggle = forwardRef(
             <HiddenInput
                 type="checkbox"
                 id={id}
+                onChange={onChange}
                 checked={checked}
                 disabled={disabled}
                 ref={ref}

--- a/src/Form/Toggle/Toggle.stories.tsx
+++ b/src/Form/Toggle/Toggle.stories.tsx
@@ -5,7 +5,7 @@ import { storiesOf } from '@storybook/react';
 import { boolean, text } from '@storybook/addon-knobs';
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 // ANCHOR
-import { colors, RootTheme } from '../../theme';
+import { RootTheme } from '../../theme';
 // SUBJECT
 import * as README from './README.md';
 import { Toggle } from './Toggle.component';
@@ -13,7 +13,7 @@ import { Toggle } from './Toggle.component';
 const { useState } = React;
 
 const StyledStory = styled.div`
-    background: ${colors.white.base};
+    background: white;
 `;
 
 storiesOf('Components/Form/Toggle', module)

--- a/src/Hero/Hero.stories.tsx
+++ b/src/Hero/Hero.stories.tsx
@@ -21,7 +21,9 @@ const StyledStory = styled('div')`
     width: 100vw;
 `;
 
-const tealGradient = `linear-gradient(224deg,${colors.tealBreaker.base},${colors.dealEnvy.light})`;
+const tealGradient = `linear-gradient(224deg,${colors.tealBreaker.base},${
+    colors.dealEnvy.light
+})`;
 
 storiesOf('Components/Hero', module)
     .addParameters({

--- a/src/Modal/Modal.component.tsx
+++ b/src/Modal/Modal.component.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 // VENDOR
 import * as StyledReactModal from 'styled-react-modal';
 import styled, { css } from '@xstyled/styled-components';
+import { th } from '@xstyled/system';
 import classnames from 'classnames';
 // COMPONENTS
 import { ModalHeader, StyledHeader } from './Header';
@@ -31,10 +32,12 @@ const StyledModal = StyledReactModal.default.styled`
     flex-direction: column;
     justify-content: space-between;
 
-    border-radius: modal;
-    ${({ background = 'neutrals.white.base' }: ModalProps) =>
-        css({ backgroundColor: background })};
-    ${({ color }: ModalProps) => css({ color })}
+    ${({ background = 'neutrals.white.base', color }: ModalProps) =>
+        css({
+            background: th.color(background),
+            color,
+            borderRadius: 'modal',
+        })};
     box-shadow: ${({
         shadow = '0 0.375rem 0.5rem 0.25rem rgba(0,0,0,0.13)',
     }: ModalProps) => shadow};
@@ -49,7 +52,9 @@ const StyledModal = StyledReactModal.default.styled`
     // Footer (respectively) are also used.
     ${StyledContent} {
         padding: ${({ size = defaultSize }: ModalProps) =>
-            `4rem ${Sizes[size].contentPadding}rem 0 ${Sizes[size].contentPadding}rem`};
+            `4rem ${Sizes[size].contentPadding}rem 0 ${
+                Sizes[size].contentPadding
+            }rem`};
         &:last-child {
             padding-bottom: ${({ size = defaultSize }: ModalProps) =>
                 `${Sizes[size].contentPadding}rem`};

--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -226,7 +226,7 @@ storiesOf('Components/Modal', module)
                         <Close reverse onClick={() => setIsOpen(false)} />
                         <Content>
                             <Typography
-                                tag="p"
+                                tag="h2"
                                 scale={24}
                                 weight={600}
                                 align="center"

--- a/src/Modal/index.ts
+++ b/src/Modal/index.ts
@@ -1,1 +1,1 @@
-export { Modal } from './Modal.component';
+export { Modal, BaseModalBackground, ModalProvider } from './Modal.component';

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,6 @@ export {
 } from './theme';
 export { Card } from './Card';
 export { Hero } from './Hero';
-export { Modal } from './Modal';
+export { Modal, BaseModalBackground, ModalProvider } from './Modal';
 export { Input, Toggle, Radio, ControlLabel } from './Form';
 export * from './Icon';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -24,4 +24,7 @@ export const RootTheme = {
     radii: { none: '0', base: '4px', modal: '8px', circular: '1000px' },
     [BUTTON_KEY]: BUTTON_THEME,
     colors: ColorsTheme,
+    breakpoints: {
+        xs: 0,
+    },
 };


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config

---------
**Outline your feature or bug-fix below**

Stops Toggle from triggering onChange twice
Fixes Modal border radius (didn't have any)
Exports ModalProvider and BaseModalBackground from Modal
