### PR TITLE
docs: Adds documentation for Modal component

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "author": "Kameron (@sharkparty)",
     "dependencies": {
         "@reach/component-component": "^0.1.3",
-        "@retailmenot/anchor": "^0.0.1-alpha.31",
+        "@retailmenot/anchor": "^0.0.1-beta.8",
         "@xstyled/styled-components": "^1.5.2",
         "babel-plugin-styled-components": "^1.10.6",
         "classnames": "^2.2.6",

--- a/docs/src/components/CodePreview/CodePreview.component.tsx
+++ b/docs/src/components/CodePreview/CodePreview.component.tsx
@@ -1,3 +1,19 @@
+/*
+    This component is polymorphic. It can be either a static code block, or it can be an interactive
+    code editor. This is an example of it being used as a static code block.
+
+    ```jsx
+        const x = 0;
+    ```
+
+    And this is an example of it being used as an interactive code editor. Note that only components
+    can be used in the editor and only Anchor components at that.
+
+    ```tsx live
+        <AddEvent />
+    ```
+*/
+
 // REACT
 import * as React from 'react';
 // VENDOR

--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -132,6 +132,10 @@ const StyledLi = styled.li`
     padding-bottom: 0.5rem;
 `;
 
+const StyledHr = styled('hr')`
+    margin: 2rem 0;
+`;
+
 const StyledTable = styled.table``;
 
 const Components: any = {};
@@ -192,6 +196,7 @@ Components.h6 = ({ children, ...props }: any) => (
         id={`${children.split(' ').join('-')}`.toLowerCase()}
         weight={600}
         tag="h6"
+        mb="1"
         {...props}
         children={children}
     />
@@ -214,6 +219,7 @@ Components.li = (props: any) => (
         <Typography {...props} />
     </StyledLi>
 );
+Components.hr = (props: any) => <StyledHr {...props} />;
 // TODO: This only binds to MD tables, not HTML
 Components.table = (props: any) => <StyledTable {...props} />;
 

--- a/docs/src/components/ModalExample/ModalAndButton.component.tsx
+++ b/docs/src/components/ModalExample/ModalAndButton.component.tsx
@@ -1,0 +1,47 @@
+/*
+    This component exists for the modal.mdx documentation.
+
+    The code here should be copied verbatim for the "ModalAndButton Component Example" section.
+*/
+
+import * as React from 'react';
+import { Modal, Button, Typography } from '@retailmenot/anchor';
+
+const { Header, Footer, Close, Content } = Modal;
+
+export const ModalAndButton = () => {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    return (
+        <React.Fragment>
+            <Button onClick={() => setIsOpen(true)}>
+                Click Me For a Modal!
+            </Button>
+
+            <Modal
+                size="sm"
+                isOpen={isOpen}
+                onBackgroundClick={() => setIsOpen(false)}
+                onEscapeKeydown={() => setIsOpen(false)}
+            >
+                <Header title="Modal Example">
+                    <Close onClick={() => setIsOpen(false)} />
+                </Header>
+
+                <Content>
+                    <Typography tag="h3">Hello World!</Typography>
+                </Content>
+
+                <Footer>
+                    <Button
+                        block
+                        onClick={() => setIsOpen(false)}
+                        variant="minimal"
+                    >
+                        Cancel
+                    </Button>
+                </Footer>
+            </Modal>
+        </React.Fragment>
+    );
+};

--- a/docs/src/components/ModalExample/ModalExample.component.tsx
+++ b/docs/src/components/ModalExample/ModalExample.component.tsx
@@ -1,0 +1,46 @@
+/*
+    This component exists for the modal.mdx documentation.
+
+    Although this component is very close to the examples given in the Modal documentation, the key
+    difference is that in this code I'm importing the ModalProvider rather than putting it at the
+    top of the gatsby site like I did in the code examples. The ThemeProvider and RootTheme are
+    already in the Page.component.
+*/
+
+import * as React from 'react';
+import styled from 'styled-components';
+import { Typography, ModalProvider } from '@retailmenot/anchor';
+import { ModalAndButton } from './ModalAndButton.component';
+
+const StyledModalExample = styled.div`
+    border: solid black 1px;
+    padding: 1rem;
+    margin: 1rem;
+    background-color: white;
+    max-width: 30rem;
+`;
+
+export const ModalExample = () => (
+        <ModalProvider>
+            <StyledModalExample>
+                <Typography tag="h2" mt="0">
+                    An Example Page
+                </Typography>
+
+                <section>
+                    <Typography tag="div" pb="2">
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        Nunc tempor ante quis mauris hendrerit, sed egestas
+                        nulla porttitor. Pellentesque habitant morbi tristique
+                        senectus et netus et malesuada fames ac turpis egestas.
+                        Quisque convallis, risus non ornare lacinia, enim neque
+                        malesuada nisi, nec bibendum enim orci eu diam. Nunc
+                        vulputate placerat magna non ultrices. Aenean pharetra
+                        ante at sapien facilisis, eget accumsan quam suscipit.
+                    </Typography>
+
+                    <ModalAndButton />
+                </section>
+            </StyledModalExample>
+        </ModalProvider>
+);

--- a/docs/src/components/ModalExample/index.ts
+++ b/docs/src/components/ModalExample/index.ts
@@ -1,0 +1,1 @@
+export { ModalExample } from './ModalExample.component';

--- a/docs/src/pages/components/icon.mdx
+++ b/docs/src/pages/components/icon.mdx
@@ -21,7 +21,7 @@ There are currently <IconCount /> icons available. Note that you can try any of 
 
 #### Live Code Editor
 
-```tsx
+```tsx live
 <section>
     <div>
         <Star color="red" />

--- a/docs/src/pages/components/modal.mdx
+++ b/docs/src/pages/components/modal.mdx
@@ -1,3 +1,386 @@
+import { Link } from 'gatsby';
+import { Typography } from '@retailmenot/anchor';
+import { ModalExample } from '../../components/ModalExample';
+
 <br />
 
 # Modal
+
+The Modal component is an overlay over all content on the page, presenting its own content area
+for the user to interact with. Here is an example of the modal:
+
+<br />
+
+<ModalExample />
+
+<br />
+
+There are several components to `Modal` that interact with each other to provide the complete
+experience. As noted after the code sample below some are not required.
+
+###### Imports
+```js
+import { Modal, RootTheme, ModalProvider } from '@retailmenot/anchor';
+import { ThemeProvider } from 'styled-components';
+
+const { Header, Footer, Close, Content } = Modal;
+```
+
+<br />
+
+* `Modal` is the key component, and without it there is no modal.
+* `Header` **is not required**. It creates a header at the top of the modal that allows for a title,
+with configurable background color and font color. If using the `Close` component (noted below) it's
+a good idea to make it a child of the Header.
+* `Footer` **is not required**. It creates a footer at the bottom of the modal with configurable padding
+and background color.
+* `Close` **is not required**. It provides a styled `button` element to close the modal. It is
+recommended to make the `Close` component a child of `Header`. *NOTE! By itself,  this button has no
+functionality. A function to close the modal will have to be assigned as an `onClick` event.*
+* `Content` **is not required**. It serves as a styled wrapper for the actual content that will
+show up in the modal. It has no props and serves only to correctly position the content within the
+modal. Content has a set amount of padding on all sides, however it will lose its top padding if
+used with `Header`, and it will lose it's bottom padding if used with `Footer`.
+* `RootTheme` provides a number of css styles that the modal will use.
+* `ModalProvider` will set the root portal where `Modal`s will be rendered.
+* `ThemeProvider` comes from the <a href="https://www.styled-components.com/" target="_blank">`styled-components`</a> library
+and will apply the `RootTheme` to the modal.
+
+*NOTE! It's best to put `ThemeProvider`  and `ModalProvider` components higher up in the application
+tree. `ThemeProvider` will make the styles from `RootTheme` available to any Anchor component in the
+application if it is defined near the top. `ModalProvider` only needs to be used a single time, and
+if it wraps an application that means that multiple `Modal` components can be used but with just a
+single `ModalProvider`.*
+
+---
+
+## Putting it Together
+
+Lets pretend we have an extremely basic React application called `App`. The `index.js` file where `App`
+gets attached to the **DOM** is the perfect place to initialize `ThemeProvider` and `ModalProvider`.
+
+###### Example Application
+```jsx
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import App from './components/App'; // This path is just an example
+import { ThemeProvider } from 'styled-components';
+import { RootTheme, ModalProvider} from '@retailmenot/anchor';
+
+const Root = (
+    <ThemeProvider theme={RootTheme}>
+        <ModalProvider>
+            <App />
+        </ModalProvider>
+    </ThemeProvider>
+);
+
+document.addEventListener('DOMContentLoaded', () => {
+    const wrapper = document.getElementById('app');
+    ReactDOM.render(Root, wrapper);
+});
+```
+
+<br />
+
+By wrapping our application in these providers, we don't have to do anything else except build the
+modal and the button to open it.
+
+In the code below, I've imported the <Link to="/components/modal">`Button`</Link> and <Link to="/components/typography">`Typography`</Link> components
+from Anchor just to make things look a little nicer. I'm also using a **React hook** to track the
+state of the modal, `isOpen`, with its corresponding function to change that state, `setIsOpen`.
+
+I'm putting both the button to open the `Modal` and the `Modal` itself in the same file in this
+example, but that's not required. As long as the `isOpen` prop of `Modal` receives a value that
+changes, that's all that is necessary to open and close the modal.
+
+###### ModalAndButton Component Example
+```jsx
+import * as React from 'react';
+import { Modal, Button, Typography } from '@retailmenot/anchor';
+
+const { Header, Footer, Close, Content } = Modal;
+
+export const ModalAndButton = () => {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    return(
+        <React.Fragment>
+            <Button onClick={() => setIsOpen(true)}>
+                Click Me For a Modal!
+            </Button>
+
+            <Modal
+                size="sm"
+                isOpen={isOpen}
+                onBackgroundClick={() => setIsOpen(false)}
+                onEscapeKeydown={() => setIsOpen(false)}
+            >
+                <Header title="Modal Example">
+                    <Close onClick={() => setIsOpen(false)} />
+                </Header>
+
+                <Content>
+                    <Typography tag="h3">Hello World!</Typography>
+                </Content>
+
+                <Footer>
+                    <Button
+                        block
+                        onClick={() => setIsOpen(false)}
+                        variant="minimal"
+                    >
+                        Cancel
+                    </Button>
+                </Footer>
+            </Modal>
+        </React.Fragment>
+    );
+};
+```
+
+<br />
+
+Now that we have the providers declared at the top of our application and we've created our `ModalAndButton`
+component above, it's time to use it. Below is an example page that exists within our application.
+It's as simple as dropping in our `ModalAndButton` into the page to have it work!
+
+###### Page Example
+```jsx
+import * as React from 'react';
+import styled from 'styled-components';
+import { Typography } from '@retailmenot/anchor';
+import { ModalAndButton } from './components/ModalAndButton'; // This path is just an example
+
+const StyledPageExample = styled.div`
+    border:solid black 1px;
+    padding:1rem;
+    margin: 1rem;
+    background-color: white;
+    max-width: 30rem;
+`;
+
+export const PageExample = () => (
+    <StyledPageExample>
+        <Typography tag="h2" pt="0">An Example Page</Typography>
+
+        <section>
+            <Typography tag="div">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Nunc tempor ante quis mauris hendrerit, sed egestas nulla porttitor.
+                Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+                Quisque convallis, risus non ornare lacinia, enim neque malesuada nisi, nec bibendum enim orci eu diam.
+                Nunc vulputate placerat magna non ultrices.
+                Aenean pharetra ante at sapien facilisis, eget accumsan quam suscipit.
+            </Typography>
+
+            <ModalAndButton />
+        </section>
+    </StyledPageExample>
+);
+```
+
+<br />
+
+And voila! Here is our `PageExample` component rendered with our `ModalAndButton`!
+
+<br />
+
+<ModalExample />
+
+<br /><br />
+
+## API's
+
+---
+
+### Modal
+
+The `Modal` component is based off of `styled-react-modal` and as such accepts any of those <Typography tag="a" href="https://github.com/AlexanderRichey/styled-react-modal#modal" target="_blank">props</Typography>.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>background</td>
+            <td>
+                Sets the background color of the modal. It uses Anchor's <Link to="/theme">theme</Link> colors
+                by default, but any color value can be provided.
+            </td>
+            <td>
+                String
+            </td>
+            <td>white.base</td>
+        </tr>
+        <tr>
+            <td>color</td>
+            <td>
+                Sets the font color of the modal. It uses Anchor's <Link to="/theme">theme</Link> colors
+                by default, but any color value can be provided.
+            </td>
+            <td>String</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td>height</td>
+            <td>
+                A specific height of the modal. Accepts any standard css unit, i.e. 500px, 50%, etc.
+            </td>
+            <td>String</td>
+            <td>42.375rem</td>
+        </tr>
+        <tr>
+            <td>margin</td>
+            <td>
+                Applies a margin to the Modal container. It is not recommended to change this value
+                unless you do not want the modal centered. Accepts any standard margin shorthand
+                value, i.e. '5px 10px 8px'.
+            </td>
+            <td>String</td>
+            <td>auto</td>
+        </tr>
+        <tr>
+            <td>shadow</td>
+            <td>
+                Applies a box-shadow to the Modal container. Accepts any standard box-shadow shorthand
+                value.
+            </td>
+            <td>String</td>
+            <td>0 0.375rem 0.5rem 0.25rem rgba(0,0,0,0.13)</td>
+        </tr>
+        <tr>
+            <td>size</td>
+            <td>
+                Changes the size of the modal.
+            </td>
+            <td>
+                'lg' | 'sm'
+            </td>
+            <td>'lg'</td>
+        </tr>
+        <tr>
+            <td>width</td>
+            <td>
+                A specific width of the modal. Accepts any standard css unit, i.e. 500px, 50%, etc.
+                If no width is specified, the size is used instead.
+            </td>
+            <td>String</td>
+            <td>-</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+### Header
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>background</td>
+            <td>
+                Sets the background color of the header. It uses Anchor's <Link to="/theme">theme</Link> colors
+                by default, but any color value can be provided.
+            </td>
+            <td>
+                String
+            </td>
+            <td>white.base</td>
+        </tr>
+        <tr>
+            <td>color</td>
+            <td>
+                Sets the font color of the title. It uses Anchor's <Link to="/theme">theme</Link> colors
+                by default, but any color value can be provided.
+            </td>
+            <td>String</td>
+            <td>charcoal.light</td>
+        </tr>
+        <tr>
+            <td>title</td>
+            <td>
+                Renders the supplied text with Anchor's <Link to="/components/typography">Typography</Link> component with a scale of
+                20 and a weight of bold.
+            </td>
+            <td>String</td>
+            <td>-</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+### Footer
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>background</td>
+            <td>
+                Sets the background color of the footer.
+            </td>
+            <td>
+                String
+            </td>
+            <td>transparent</td>
+        </tr>
+        <tr>
+            <td>padding</td>
+            <td>
+                Sets the padding for the footer.
+            </td>
+            <td>String</td>
+            <td>-</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+### Close
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>align</td>
+            <td>
+                Aligns the close button to the left or right corner of its parent element.
+            </td>
+            <td>'right' | 'left'</td>
+            <td>-</td>
+        </tr>
+    </tbody>
+</table>
+
+<br /><br />

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -27,7 +27,7 @@ These are the default styles for Typography:
 
 #### Inline Code Editor
 
-```tsx
+```tsx live
 <div>
     <Typography tag="p">
         The quick <Typography tag="span" transform="uppercase" color="#ff0000" weight="bolder">red</Typography> fox


### PR DESCRIPTION
docs: Created new components to assemble the pieces of the modal as an example

fix: Made the code block live for icon.mdx

docs: added the usage of the modal components to modal.mdx

docs: Added api for Modal

chore: updated anchor to 0.0.1-beta.8 for doc site

feat: added a StyledHr component to mdx's custom component bindings

feat: added a slight bottom margin to mdx custom h6 tag

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Adds documentation for the modal component. This includes components to help illustrate its use and detailed code blocks. No interactive code editor here, it didn't make sense with how Modal is designed.
