### PR TITLE
docs: Adding Avatar to docs

### DIFF
--- a/docs/src/components/CodePreview/CodePreview.component.tsx
+++ b/docs/src/components/CodePreview/CodePreview.component.tsx
@@ -14,11 +14,7 @@ import Component from '@reach/component-component';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 // tslint:disable-next-line: no-submodule-imports
 import github from 'prism-react-renderer/themes/github';
-import {
-    AutoComplete,
-    Collapse,
-    CollapseGroup
-} from '@retailmenot/anchor';
+import { AutoComplete, Collapse, CollapseGroup } from '@retailmenot/anchor';
 // COMPONENTS
 import * as Anchor from '../../../../src';
 // THEME
@@ -37,14 +33,14 @@ const StyledErrorElement = styled(LiveError)`
 `;
 
 const StyledContainerElement = styled.div`
-    margin: 1rem 0;
+    margin: 2rem 0;
     display: block;
 `;
 
 const StyledLiveEditor = styled(LiveEditor)<LiveEditorProps>`
     background-color: ${colors.charcoal.base};
-    border-bottom-left-radius: .25rem;
-    border-bottom-right-radius: .25rem;
+    border-top-left-radius: .25rem;
+    border-top-right-radius: .25rem;
     ${CodePreviewForcedStyles};
     // This library uses element-based colors to set some of its colors, which necessitates the '!important' below
     .token-line {
@@ -100,15 +96,16 @@ const StyledLiveEditor = styled(LiveEditor)<LiveEditorProps>`
 const StyledLivePreview = styled(LivePreview)<PreProps>`
     ${CodePreviewForcedStyles};
     padding: 1rem;
-    border: solid thin ${colors.silver.base};
-    border-top-left-radius: 0.25rem;
-    border-top-right-radius: 0.25rem;
+    border: solid thin ${colors.silver.dark};
+    border-bottom-left-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
 `;
 
 interface CodePreviewProps {
     children?: any;
     className?: string;
     live?: boolean;
+    title?: string;
 }
 
 const scope = {
@@ -128,12 +125,19 @@ export const CodePreview = ({
     children,
     className,
     live = false,
+    title = 'Live Code Editor',
 }: CodePreviewProps): React.ReactElement<any> => {
-    const language = (className) ? className.replace(/language-/, '') : 'javascript';
+    const language = className
+        ? className.replace(/language-/, '')
+        : 'javascript';
 
     if (live) {
-        return(
+        return (
             <StyledContainerElement>
+                <Anchor.Typography tag="h6" pb="3" m="0" weight={600}>
+                    {title}
+                </Anchor.Typography>
+
                 <LiveProvider code={children} scope={scope}>
                     <StyledLiveEditor wrap="true" />
                     <StyledLivePreview />
@@ -146,13 +150,24 @@ export const CodePreview = ({
     // This is code taken from MDX's own documentation on rendering a code block
     // https://mdxjs.com/guides/syntax-highlighting/#build-a-codeblock-component
     return (
-        <Highlight {...defaultProps} code={children} language={language} theme={github}>
-            {({className, style, tokens, getLineProps, getTokenProps}) => (
-                <pre className={className} style={{...style, padding: '20px'}}>
+        <Highlight
+            {...defaultProps}
+            code={children}
+            language={language}
+            theme={github}
+        >
+            {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                <pre
+                    className={className}
+                    style={{ ...style, padding: '20px' }}
+                >
                     {tokens.map((line, i) => (
-                        <div key={i} {...getLineProps({line, key: i})}>
+                        <div key={i} {...getLineProps({ line, key: i })}>
                             {line.map((token, key) => (
-                                <span key={key} {...getTokenProps({token, key})} />
+                                <span
+                                    key={key}
+                                    {...getTokenProps({ token, key })}
+                                />
                             ))}
                         </div>
                     ))}

--- a/docs/src/components/IconList/IconList.component.tsx
+++ b/docs/src/components/IconList/IconList.component.tsx
@@ -11,26 +11,26 @@ const StyledIconList = styled.section`
     display: flex;
     align-items: flex-start;
     flex-wrap: wrap;
-    height:100%;
-    padding-top:1rem;
+    height: 100%;
+    padding-top: 1rem;
 
     .cell {
         width: 12.5%;
-        height:4rem;
-        text-align:center;
-        padding-bottom:2rem;
+        height: 4rem;
+        text-align: center;
+        padding-bottom: 2rem;
     }
 `;
 
 const IconTitle = styled(Typography)`
-    padding-bottom:0.5rem !important;
-    margin:0;
+    padding-bottom: 0.5rem !important;
+    margin: 0;
 `;
 
 // A visual listing of every icon along with its name.
 export const IconList = () => (
     <StyledIconList>
-        {iconKeys.map( key => (
+        {iconKeys.map(key => (
             <div className="cell" key={`cell-${key}`}>
                 <IconTitle tag="h6">{key}</IconTitle>
                 {React.createElement(Icons[key], {})}

--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -120,15 +120,16 @@ const StyledPrimaryNav = styled.nav`
 // These are standard markdown styles for an inlineCode block. Can't use 'code' because that is tied
 // to the CodePreview component.
 const StyledInlineCode = styled.span`
-    background-color: rgba(27,31,35,.05);
-    font-family: "SFMono-Regular",Consolas,Liberation Mono,Menlo,Courier,monospace;
+    background-color: rgba(27, 31, 35, 0.05);
+    font-family: 'SFMono-Regular', Consolas, Liberation Mono, Menlo, Courier,
+        monospace;
     border-radius: 3px;
-    padding: .2em .4em;
+    padding: 0.2em 0.4em;
     font-size: 85%;
 `;
 
 const StyledLi = styled.li`
-    padding-bottom: .5rem;
+    padding-bottom: 0.5rem;
 `;
 
 const StyledTable = styled.table``;
@@ -208,7 +209,11 @@ Components.strong = (props: any) => (
 );
 Components.ul = (props: any) => <ul {...props} />;
 Components.ol = (props: any) => <ol {...props} />;
-Components.li = (props: any) => <StyledLi><Typography {...props} /></StyledLi>;
+Components.li = (props: any) => (
+    <StyledLi>
+        <Typography {...props} />
+    </StyledLi>
+);
 // TODO: This only binds to MD tables, not HTML
 Components.table = (props: any) => <StyledTable {...props} />;
 

--- a/docs/src/components/Navigation/AddLocation.tsx
+++ b/docs/src/components/Navigation/AddLocation.tsx
@@ -6,9 +6,11 @@ import { Location } from '@reach/router';
 export function AddLocation(Component: any) {
     return class EnhancedWithLocation extends React.Component {
         render() {
-            return(
+            return (
                 <Location>
-                    {locationProps => <Component {...locationProps} {...this.props} />}
+                    {locationProps => (
+                        <Component {...locationProps} {...this.props} />
+                    )}
                 </Location>
             );
         }

--- a/docs/src/components/Navigation/SideNavigation/SideNavigation.component.tsx
+++ b/docs/src/components/Navigation/SideNavigation/SideNavigation.component.tsx
@@ -44,46 +44,53 @@ class SideNavigation extends React.PureComponent<SideNavigationProps> {
     componentWillMount() {
         const { pathname } = this.props.location;
 
-        const mainOpenIndex = sections.reduce((openIndex: number, section: SectionProperties, index: number) => {
-            const { pattern } = section;
-            // Compares the current url with the path associated to a section and gets its index if it matches.
-            return (pattern.length && pathname.includes(pattern)) ? index : openIndex;
-          }, 0);
+        const mainOpenIndex = sections.reduce(
+            (openIndex: number, section: SectionProperties, index: number) => {
+                const { pattern } = section;
+                // Compares the current url with the path associated to a section and gets its index if it matches.
+                return pattern.length && pathname.includes(pattern)
+                    ? index
+                    : openIndex;
+            },
+            0
+        );
 
-        this.setState({mainOpenIndex});
+        this.setState({ mainOpenIndex });
     }
 
     render() {
         const { mainOpenIndex } = this.state;
 
-        return ( mainOpenIndex !== false && (
-            <StyledCollapseGroup
-                variant="compact"
-                openIndex={mainOpenIndex}
-                accordion
-            >
-                {sections.map((section: SectionProperties, i: number) => (
-                    <Collapse
-                        openedText={section.title}
-                        key={`collapse-key-${i}`}
-                    >
-                        <ul>
-                            {section.links.map(
-                                (link: LinkProperties, j: number) => (
-                                    <li key={`link-key-${j}`}>
-                                        <Link
-                                            to={link.path}
-                                            activeClassName="active"
-                                        >
-                                            {link.title}
-                                        </Link>
-                                    </li>
-                                )
-                            )}
-                        </ul>
-                    </Collapse>
-                ))}
-            </StyledCollapseGroup>)
+        return (
+            mainOpenIndex !== false && (
+                <StyledCollapseGroup
+                    variant="compact"
+                    openIndex={mainOpenIndex}
+                    accordion
+                >
+                    {sections.map((section: SectionProperties, i: number) => (
+                        <Collapse
+                            openedText={section.title}
+                            key={`collapse-key-${i}`}
+                        >
+                            <ul>
+                                {section.links.map(
+                                    (link: LinkProperties, j: number) => (
+                                        <li key={`link-key-${j}`}>
+                                            <Link
+                                                to={link.path}
+                                                activeClassName="active"
+                                            >
+                                                {link.title}
+                                            </Link>
+                                        </li>
+                                    )
+                                )}
+                            </ul>
+                        </Collapse>
+                    ))}
+                </StyledCollapseGroup>
+            )
         );
     }
 }

--- a/docs/src/components/Navigation/SideNavigation/sections.ts
+++ b/docs/src/components/Navigation/SideNavigation/sections.ts
@@ -23,6 +23,10 @@ export const sections = [
                 path: '/components/autocomplete/',
             },
             {
+                title: 'Avatar',
+                path: '/components/avatar/',
+            },
+            {
                 title: 'Badge',
                 path: '/components/badge/',
             },

--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -1,2 +1,46 @@
+<br />
+
 # Avatar
+
+The `Avatar` component renders a generic avatar graphic, or a stylized label.
+
+```tsx live
+    <section>
+        <Typography tag="div" pb="4">
+            <Typography tag="h3">Avatar with a label...</Typography>
+            <Avatar label="ps" />
+        </Typography>
+
+        <Typography tag="div">
+            <Typography tag="h3">Avatar without a label...</Typography>
+            <Avatar />
+        </Typography>
+    </section>
+```
+
+<br />
+
+### API
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>label</td>
+            <td>Displays the string rather than the avatar graphic. Although any length string can
+                be provided, only the first two characters will be displayed (such as initials) and
+                also capitalized.
+            </td>
+            <td>String</td>
+            <td>-</td>
+        </tr>
+    </tbody>
+</table>
 


### PR DESCRIPTION
fix: Added link to Avatar  to SideNavigation

docs: Added Avatar to live code editor

docs: Add more examples for Avatar

feat: CodePreview as live editor now has a title configurable by prop

fix: Corrected border-radius application for CodePreview component

feat: Added extra margin to CodePreview top and bottom

docs: Cleaned up formatting for Avatar.mdx

chore: prettier

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

This adds the `Avatar` documentation to the doc site, adds a small upgrade to the `CodePreview` component allowing for a title to be passed and used for the `live` mode, and some small format changes/fixes to the `CodePreview` component.
