### PR TITLE
docs: Adds Hero to doc site

### DIFF
--- a/docs/src/components/CodePreview/CodePreview.component.tsx
+++ b/docs/src/components/CodePreview/CodePreview.component.tsx
@@ -12,6 +12,13 @@
     ```tsx live
         <AddEvent />
     ```
+
+    A default title of "Inline Code Editor" or "Example" is displayed by default depending on if the
+    'live' prop is passed. To hide it, pass the hideTitle prop.
+
+    ```tsx hideTitle
+        <AddEvent />
+    ```
 */
 
 // REACT
@@ -30,7 +37,12 @@ import Component from '@reach/component-component';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 // tslint:disable-next-line: no-submodule-imports
 import github from 'prism-react-renderer/themes/github';
-import { AutoComplete, Collapse, CollapseGroup } from '@retailmenot/anchor';
+import {
+    AutoComplete,
+    Collapse,
+    CollapseGroup,
+    Typography,
+} from '@retailmenot/anchor';
 // COMPONENTS
 import * as Anchor from '../../../../src';
 // THEME
@@ -117,11 +129,16 @@ const StyledLivePreview = styled(LivePreview)<PreProps>`
     border-bottom-right-radius: 0.25rem;
 `;
 
+const StyledCodeBlock = styled('pre')`
+    padding: 1.25rem;
+    background-color: ${colors.silver.base};
+`;
+
 interface CodePreviewProps {
     children?: any;
     className?: string;
     live?: boolean;
-    title?: string;
+    hideTitle?: boolean;
 }
 
 const scope = {
@@ -141,18 +158,21 @@ export const CodePreview = ({
     children,
     className,
     live = false,
-    title = 'Live Code Editor',
+    hideTitle = false,
 }: CodePreviewProps): React.ReactElement<any> => {
     const language = className
         ? className.replace(/language-/, '')
         : 'javascript';
+    const title = live ? 'Live Code Editor' : 'Example';
 
     if (live) {
         return (
             <StyledContainerElement>
-                <Anchor.Typography tag="h6" pb="3" m="0" weight={600}>
-                    {title}
-                </Anchor.Typography>
+                {!hideTitle && (
+                    <Typography tag="h6" pb="3" m="0" weight={600}>
+                        {title}
+                    </Typography>
+                )}
 
                 <LiveProvider code={children} scope={scope}>
                     <StyledLiveEditor wrap="true" />
@@ -166,29 +186,34 @@ export const CodePreview = ({
     // This is code taken from MDX's own documentation on rendering a code block
     // https://mdxjs.com/guides/syntax-highlighting/#build-a-codeblock-component
     return (
-        <Highlight
-            {...defaultProps}
-            code={children}
-            language={language}
-            theme={github}
-        >
-            {({ className, style, tokens, getLineProps, getTokenProps }) => (
-                <pre
-                    className={className}
-                    style={{ ...style, padding: '20px' }}
-                >
-                    {tokens.map((line, i) => (
-                        <div key={i} {...getLineProps({ line, key: i })}>
-                            {line.map((token, key) => (
-                                <span
-                                    key={key}
-                                    {...getTokenProps({ token, key })}
-                                />
-                            ))}
-                        </div>
-                    ))}
-                </pre>
+        <StyledContainerElement>
+            {!hideTitle && (
+                <Typography tag="h6" pb="0" m="0" weight={600}>
+                    {title}
+                </Typography>
             )}
-        </Highlight>
+
+            <Highlight
+                {...defaultProps}
+                code={children}
+                language={language}
+                theme={github}
+            >
+                {({ className, tokens, getLineProps, getTokenProps }) => (
+                    <StyledCodeBlock className={className}>
+                        {tokens.map((line, i) => (
+                            <div key={i} {...getLineProps({ line, key: i })}>
+                                {line.map((token, key) => (
+                                    <span
+                                        key={key}
+                                        {...getTokenProps({ token, key })}
+                                    />
+                                ))}
+                            </div>
+                        ))}
+                    </StyledCodeBlock>
+                )}
+            </Highlight>
+        </StyledContainerElement>
     );
 };

--- a/docs/src/components/ModalExample/ModalExample.component.tsx
+++ b/docs/src/components/ModalExample/ModalExample.component.tsx
@@ -21,26 +21,26 @@ const StyledModalExample = styled.div`
 `;
 
 export const ModalExample = () => (
-        <ModalProvider>
-            <StyledModalExample>
-                <Typography tag="h2" mt="0">
-                    An Example Page
+    <ModalProvider>
+        <StyledModalExample>
+            <Typography tag="h2" mt="0">
+                An Example Page
+            </Typography>
+
+            <section>
+                <Typography tag="div" pb="2">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Nunc tempor ante quis mauris hendrerit, sed egestas nulla
+                    porttitor. Pellentesque habitant morbi tristique senectus et
+                    netus et malesuada fames ac turpis egestas. Quisque
+                    convallis, risus non ornare lacinia, enim neque malesuada
+                    nisi, nec bibendum enim orci eu diam. Nunc vulputate
+                    placerat magna non ultrices. Aenean pharetra ante at sapien
+                    facilisis, eget accumsan quam suscipit.
                 </Typography>
 
-                <section>
-                    <Typography tag="div" pb="2">
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                        Nunc tempor ante quis mauris hendrerit, sed egestas
-                        nulla porttitor. Pellentesque habitant morbi tristique
-                        senectus et netus et malesuada fames ac turpis egestas.
-                        Quisque convallis, risus non ornare lacinia, enim neque
-                        malesuada nisi, nec bibendum enim orci eu diam. Nunc
-                        vulputate placerat magna non ultrices. Aenean pharetra
-                        ante at sapien facilisis, eget accumsan quam suscipit.
-                    </Typography>
-
-                    <ModalAndButton />
-                </section>
-            </StyledModalExample>
-        </ModalProvider>
+                <ModalAndButton />
+            </section>
+        </StyledModalExample>
+    </ModalProvider>
 );

--- a/docs/src/pages/components/collapse.mdx
+++ b/docs/src/pages/components/collapse.mdx
@@ -11,8 +11,6 @@ does not simply show/hide content, it re-renders it.
 When using the **Live Code Editor**, you can use any <Link to="/components/icon">Icon component</Link>
 available in **Anchor** for the `openedIcon` and `closedIcon` props.
 
-#### Live Code Editor
-
 ```tsx live
 <Collapse>
     I will appear and disappear when the rendered button is clicked!
@@ -29,9 +27,9 @@ available in **Anchor** for the `openedIcon` and `closedIcon` props.
 * `openedIcon` *(React.ReactElement)*: Defaults to **`<ChevronDown />`** from `Icon`. Accepts any component to render, although realistically sticking to components from `Icon` make the most sense.
 * `closedIcon` *(React.ReactElement)*: Defaults to **`<ChevronUp />`** from `Icon`. Accepts any component to render, although realistically sticking to components from `Icon` make the most sense.
 
-#### openedIcon and/or closedIcon usage
+###### openedIcon and/or closedIcon usage
 
-```tsx live
+```tsx live hideTitle
 <Collapse
     openedIcon={<ArrowBack />}
     closedIcon={<ArrowForward />}
@@ -51,8 +49,6 @@ available in **Anchor** for the `openedIcon` and `closedIcon` props.
 # CollapseGroup
 
 The **`CollapseGroup`** component combines multiple **`Collapse`** components together, allowing a single component to apply props to all children, unifying their appearance, and adding the ability to have accordion functionality.
-
-#### Live Code Editor
 
 ```tsx live
 <CollapseGroup variant="compact">

--- a/docs/src/pages/components/hero.mdx
+++ b/docs/src/pages/components/hero.mdx
@@ -1,4 +1,197 @@
+import { Link } from 'gatsby';
+
+<br />
+
 # Hero
 
+The `Hero` component is used to display a website hero which spans from edge to edge of available
+space while centering it's content. Graphics, buttons and any other element can be used inside of a
+`Hero`.
 
+Aside from the `Hero` component itself, it has two additional components that can be deconstructed
+from it.
 
+```jsx
+    import { Hero } from '@retailmenot/anchor';
+
+    const { Title, Subtitle } = Hero;
+```
+
+Depending on how your environment is set up, you could directly access these sub-components directly
+in your jsx as shown below. This example uses the `colors` export from **Anchor** which is the basis for <Link to="/theme">themes</Link>,
+as well as the <Link to="/components/button/">`Button`</Link> component.
+
+```tsx live
+    <Hero background={colors.grapePurchase.base} minHeight="12.5rem">
+        <Hero.Title weight="bolder">TITLE!</Hero.Title>
+
+        <Hero.Subtitle scale="16">SUBTITLE!</Hero.Subtitle>
+
+        <Typography tag="div" pt="3">
+            <Button
+                variant="outline"
+                reverse
+                onClick={() => alert('Hello!')}
+            >
+                A Button
+            </Button>
+        </Typography>
+    </Hero>
+```
+
+<br />
+
+## API's
+
+---
+
+### Hero
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>align</td>
+            <td>
+                The alignment of content within the Hero.
+            </td>
+            <td>
+                'center' | 'left' | 'right' | 'inherit' | 'justify'
+            </td>
+            <td>center</td>
+        </tr>
+        <tr>
+            <td>background</td>
+            <td>
+                Sets the background color of the Hero. Any valid css color value
+                (including gradients) can be used.
+            </td>
+            <td>
+                String
+            </td>
+            <td>transparent</td>
+        </tr>
+        <tr>
+            <td>color</td>
+            <td>
+                Sets the font color of the Hero. It uses Anchor's <Link to="/theme">theme</Link> colors
+                by default, but any valid css color value can be used.
+            </td>
+            <td>
+                String
+            </td>
+            <td>white.base</td>
+        </tr>
+        <tr>
+            <td>minHeight</td>
+            <td>
+                The minimum height that the Hero should be rendered at.
+            </td>
+            <td>
+                String
+            </td>
+            <td>7.5rem</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+### Title
+
+`Title` is as a wrapper of the `Typography` component.
+Editable props are `tag`  and `weight`. Refer to `Typography`'s <Link to="/components/typography">documentation</Link> for
+more information.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>scale</td>
+            <td>
+                Note that the default tag that is used, 'h1', will prevent scale from working. Any
+                Typography 'tag' using a heading has this limitation (h1, h2, h3, h4, h5, h6).
+            </td>
+            <td>
+                -
+            </td>
+            <td>32</td>
+        </tr>
+        <tr>
+            <td>tag</td>
+            <td>
+                -
+            </td>
+            <td>
+                -
+            </td>
+            <td>h1</td>
+        </tr>
+        <tr>
+            <td>weight</td>
+            <td>
+                -
+            </td>
+            <td>
+                -
+            </td>
+            <td>600</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+### Subtitle
+
+`Subtitle` is as a wrapper of the `Typography` component. Editable props are `scale` and`weight`.
+Refer to `Typography`'s <Link to="/components/typography">documentation</Link> for more information.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>scale</td>
+            <td>
+                -
+            </td>
+            <td>
+                -
+            </td>
+            <td>18</td>
+        </tr>
+        <tr>
+            <td>weight</td>
+            <td>
+                -
+            </td>
+            <td>
+                -
+            </td>
+            <td>600</td>
+        </tr>
+    </tbody>
+</table>
+
+<br /><br />

--- a/docs/src/pages/components/icon.mdx
+++ b/docs/src/pages/components/icon.mdx
@@ -19,8 +19,6 @@ There are currently <IconCount /> icons available. Note that you can try any of 
 
 <br />
 
-#### Live Code Editor
-
 ```tsx live
 <section>
     <div>

--- a/docs/src/pages/components/modal.mdx
+++ b/docs/src/pages/components/modal.mdx
@@ -18,7 +18,6 @@ for the user to interact with. Here is an example of the modal:
 There are several components to `Modal` that interact with each other to provide the complete
 experience. As noted after the code sample below some are not required.
 
-###### Imports
 ```js
 import { Modal, RootTheme, ModalProvider } from '@retailmenot/anchor';
 import { ThemeProvider } from 'styled-components';
@@ -59,7 +58,6 @@ single `ModalProvider`.*
 Lets pretend we have an extremely basic React application called `App`. The `index.js` file where `App`
 gets attached to the **DOM** is the perfect place to initialize `ThemeProvider` and `ModalProvider`.
 
-###### Example Application
 ```jsx
 import * as React from 'react';
 import ReactDOM from 'react-dom';
@@ -95,7 +93,7 @@ example, but that's not required. As long as the `isOpen` prop of `Modal` receiv
 changes, that's all that is necessary to open and close the modal.
 
 ###### ModalAndButton Component Example
-```jsx
+```jsx hideTitle
 import * as React from 'react';
 import { Modal, Button, Typography } from '@retailmenot/anchor';
 
@@ -146,7 +144,7 @@ component above, it's time to use it. Below is an example page that exists withi
 It's as simple as dropping in our `ModalAndButton` into the page to have it work!
 
 ###### Page Example
-```jsx
+```jsx hideTitle
 import * as React from 'react';
 import styled from 'styled-components';
 import { Typography } from '@retailmenot/anchor';

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -23,10 +23,6 @@ These are the default styles for Typography:
 * `text-transform: none;`
 * `color: inherit;`
 
-<br />
-
-#### Inline Code Editor
-
 ```tsx live
 <div>
     <Typography tag="p">


### PR DESCRIPTION
fix: Rolled back ability to pass a title to CodePreview

feat: CodePreview has default title's displayed, and can be hidden via prop

docs: Updated several mdx files to take advantage of the above change

docs: Added API and a bigger example of the Hero

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Adds Hero documentation to the doc site. Also rolls back a feature introduced in a previous build, being able to pass a title as a prop to `CodePreview`. This turned out not to work because props passed by triple back-tick in an mdx file are limited to a single no-space variable.  Instead, a default title is always displayed, though can be hidden by passing the `hideTitle` prop.
