### PR TITLE
docs: Unified look of new component docs

### DIFF
--- a/docs/src/components/ModalExample/ModalExample.component.tsx
+++ b/docs/src/components/ModalExample/ModalExample.component.tsx
@@ -28,7 +28,7 @@ export const ModalExample = () => (
             </Typography>
 
             <section>
-                <Typography tag="div" pb="2">
+                <Typography tag="p" pb="2">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     Nunc tempor ante quis mauris hendrerit, sed egestas nulla
                     porttitor. Pellentesque habitant morbi tristique senectus et

--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -6,15 +6,15 @@ The `Avatar` component renders a generic avatar graphic, or a stylized label.
 
 ```tsx live
     <section>
-        <Typography tag="div" pb="4">
+        <div>
             <Typography tag="h3">Avatar with a label...</Typography>
             <Avatar label="ps" />
-        </Typography>
+        </div>
 
-        <Typography tag="div">
+        <div>
             <Typography tag="h3">Avatar without a label...</Typography>
             <Avatar />
-        </Typography>
+        </div>
     </section>
 ```
 

--- a/docs/src/pages/components/collapse.mdx
+++ b/docs/src/pages/components/collapse.mdx
@@ -12,61 +12,159 @@ When using the **Live Code Editor**, you can use any <Link to="/components/icon"
 available in **Anchor** for the `openedIcon` and `closedIcon` props.
 
 ```tsx live
-<Collapse>
-    I will appear and disappear when the rendered button is clicked!
-</Collapse>
-```
-
-<br />
-
-### Props
-
-* `isOpen` *(boolean)*: Defaults to **`false`**. Determines whether the Collapse component is open or not. Changing the value of this prop will programatticaly open/close the component, thusly not requiring a click event.
-* `openedText` *(string)*: Defaults to **`'Close'`**. The text that appears on the button as a Call To Action (CTA) when the component is open. If this prop is used and the `closedText` prop is not, `closedText` will use whatever is defined for `openedText`. This is useful if you don't actually want the CTA text to change.
-* `closedText` *(string)*: Defaults to **`'Open'`**. The text that appears on the button as a CTA when the component is closed.
-* `openedIcon` *(React.ReactElement)*: Defaults to **`<ChevronDown />`** from `Icon`. Accepts any component to render, although realistically sticking to components from `Icon` make the most sense.
-* `closedIcon` *(React.ReactElement)*: Defaults to **`<ChevronUp />`** from `Icon`. Accepts any component to render, although realistically sticking to components from `Icon` make the most sense.
-
-###### openedIcon and/or closedIcon usage
-
-```tsx live hideTitle
 <Collapse
-    openedIcon={<ArrowBack />}
     closedIcon={<ArrowForward />}
+    closedText={'Open Me'}
+    hasBottomBorder={true}
+    isOpen={false}
+    openedIcon={<ArrowBack />}
+    openedText={'Close Me'}
+    variant={'comfortable'}
 >
     <div>Hello world.</div>
 </Collapse>
 ```
 
-* `variant` *('comfortable' | 'compact' | 'none')*: Defaults to **`'comfortable'`**.
-    * **comfortable**: has considerable spacing. It is intended to be used for showing/hiding larger pieces of content.
-    * **compact**: has much tighter spacing. It is intended to be used for showing/hiding navigation elements.
-    * **none**: Applies no styling whatsoever to the component. Useful for when you want complete control of all styling via styled-components/css/etc., but still keep the functionality of the component. The component has many classes in place to try and make it easier to accomplish this.
-* `hasBottomBorder`: *(boolean)*: Defaults to **`true`**. Shows/hides the bottom border.
-
-<br />
-
-# CollapseGroup
+## CollapseGroup
 
 The **`CollapseGroup`** component combines multiple **`Collapse`** components together, allowing a single component to apply props to all children, unifying their appearance, and adding the ability to have accordion functionality.
 
 ```tsx live
-<CollapseGroup variant="compact">
+<CollapseGroup
+    accordion={true}
+    closedIcon={<ArrowForward />}
+    openedIcon={<ArrowBack />}
+    openIndex={1}
+    variant="compact"
+>
     <Collapse>
-        I will appear and disappear when the rendered button is clicked!
+        <Typography pl="5">
+            I will appear and disappear when the rendered button is clicked!
+        </Typography>
     </Collapse>
     <Collapse>
-        I will also appear and disappear when the rendered button is clicked!
+        <Typography pl="5">
+            I will also appear and disappear when the rendered button is clicked!
+        </Typography>
     </Collapse>
 </CollapseGroup>
 ```
 
-### Props
+<br />
 
-* `openedIcon` *(React.ReactElement)*: No default. Using this prop will apply the setting to all child **`Collapse`** components. Otherwise its functionality is as noted above for **`Collapse`**.
-* `closedIcon` *(React.ReactElement)*: No default. Using this prop will apply the setting to all child **`Collapse`** components. Otherwise its functionality is as noted above for **`Collapse`**.
-* `variant` *('comfortable' | 'compact' | 'none')*: No default. Using this prop will apply the setting to all child **`Collapse`** components. Otherwise its functionality is as noted above for **`Collapse`**.
-* `accordion` *(boolean)*: Defaults to **`false`**. Enables accordion functionality, where only one **`Collapse`** component can be open at a time.
-* `openIndex` *(number)*: Defaults to **`0`**. If **`accordion`** is set to **`true`**, this determines which **`Collapse`** component will start in the open state.
+## API's
+
+---
+
+### Collapse
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>closedIcon</td>
+            <td>The icon that appears when the component is closed.</td>
+            <td>ReactElement</td>
+            <td><pre>ChevronUp</pre> from <strong>Anchor</strong></td>
+        </tr>
+        <tr>
+            <td>closedText</td>
+            <td>The text that appears on the button as a CTA when the component is closed.</td>
+            <td>String</td>
+            <td>Open</td>
+        </tr>
+        <tr>
+            <td>hasBottomBorder</td>
+            <td>Shows/hides the bottom border.</td>
+            <td>Boolean</td>
+            <td>true</td>
+        </tr>
+        <tr>
+            <td>isOpen</td>
+            <td>Determines whether the Collapse component is open or not. Changing the value of this prop will programatticaly open/close the component, thusly not requiring a click event.</td>
+            <td>Boolean</td>
+            <td>false</td>
+        </tr>
+        <tr>
+            <td>openedIcon</td>
+            <td>The icon that appears when the component is opened.</td>
+            <td>ReactElement</td>
+            <td><pre>ChevronDown</pre> from <strong>Anchor</strong></td>
+        </tr>
+        <tr>
+            <td>openedText</td>
+            <td>The text that appears on the button as a CTA when the component is opened.</td>
+            <td>String</td>
+            <td>Close</td>
+        </tr>
+        <tr>
+            <td>variant</td>
+            <td>Several variants of collapse. Comfortable has considerable spacing, compact has
+                much tighter spacing, and none removes all styling.
+            </td>
+            <td>'comfortable' | 'compact' | 'none'</td>
+            <td>comfortable</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+### CollapseGroup
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>accordion</td>
+            <td>Enables accordion functionality, where only one Collapse component can be open at a time.</td>
+            <td>Boolean</td>
+            <td>false</td>
+        </tr>
+        <tr>
+            <td>closedIcon</td>
+            <td>Using this prop will apply the setting to all child Collapse components. Otherwise
+                its functionality is as noted above for Collapse.
+            </td>
+            <td>ReactElement</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td>openedIcon</td>
+            <td>Using this prop will apply the setting to all child Collapse components. Otherwise
+                its functionality is as noted above for Collapse.</td>
+            <td>ReactElement</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td>openIndex</td>
+            <td>If accordion is set to true, this determines which Collapse component will start in
+                the open state based on index.</td>
+            <td>Number</td>
+            <td>0</td>
+        </tr>
+        <tr>
+            <td>variant</td>
+            <td>Using this prop will apply the setting to all child Collapse components. Otherwise
+                its functionality is as noted above for Collapse.</td>
+            <td>'comfortable' | 'compact' | 'none'</td>
+            <td>-</td>
+        </tr>
+    </tbody>
+</table>
 
 <br /><br />

--- a/docs/src/pages/components/hero.mdx
+++ b/docs/src/pages/components/hero.mdx
@@ -27,7 +27,7 @@ as well as the <Link to="/components/button/">`Button`</Link> component.
 
         <Hero.Subtitle scale="16">SUBTITLE!</Hero.Subtitle>
 
-        <Typography tag="div" pt="3">
+        <Typography tag="p" pt="3">
             <Button
                 variant="outline"
                 reverse

--- a/docs/src/pages/components/modal.mdx
+++ b/docs/src/pages/components/modal.mdx
@@ -163,7 +163,7 @@ export const PageExample = () => (
         <Typography tag="h2" pt="0">An Example Page</Typography>
 
         <section>
-            <Typography tag="div">
+            <Typography tag="p">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                 Nunc tempor ante quis mauris hendrerit, sed egestas nulla porttitor.
                 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -39,7 +39,7 @@ These are the default styles for Typography:
 
 <br />
 
-### API
+## API
 
 <table>
     <thead>


### PR DESCRIPTION
fix (docs): Incorrect tag, div, passed to typography. Fixed all instances.

docs (Collapse): Reorganized Collapse docs to the same format as other new docs

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

First pass at trying to unify all of the new components look/format to be the same. Probably missed some things, hence a first pass.
