### PR TITLE
docs: Added documentation on the DropDown component

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,8 @@
     "dependencies": {
         "@reach/component-component": "^0.1.3",
         "@retailmenot/anchor": "^0.0.1-beta.8",
-        "@xstyled/styled-components": "^1.5.2",
+        "@xstyled/styled-components": "1.8.4",
+        "@xstyled/system": "1.8.4",
         "babel-plugin-styled-components": "^1.10.6",
         "classnames": "^2.2.6",
         "gatsby": "^2.13.31",

--- a/docs/src/components/CodePreview/CodePreview.component.tsx
+++ b/docs/src/components/CodePreview/CodePreview.component.tsx
@@ -48,7 +48,8 @@ import * as Anchor from '../../../../src';
 // THEME
 // import { TableCSS } from '../Layout/Page/Page.component';
 import { colors } from '../../../../src/theme';
-import { BottomArea, MoreInfo } from '../CardExample';
+import { BottomArea, MoreInfo, CardExample } from '../CardExample';
+import { MouseOverMe, MyList } from '../DropDownExample';
 
 // TODO: add CDN Inconsolata font
 
@@ -61,8 +62,14 @@ const StyledErrorElement = styled(LiveError)`
     ${CodePreviewForcedStyles};
 `;
 
-const StyledContainerElement = styled.div`
-    margin: 2rem 0;
+interface StyledContainerElementProps {
+    // Hiding the title will reduce the amount of top padding, allowing for another title to be
+    // placed closer to the code block.
+    hideTitle?: boolean;
+}
+
+const StyledContainerElement = styled.div<StyledContainerElementProps>`
+    margin: ${props => (!props.hideTitle ? '0  0 2rem 0' : '2rem 0')};
     display: block;
 `;
 
@@ -149,9 +156,14 @@ const scope = {
     AutoComplete,
     Collapse,
     CollapseGroup,
-    // Example Components
+
+    // -Example Components-
+    // Card
     BottomArea,
     MoreInfo,
+    // DropDown
+    MouseOverMe,
+    MyList,
 };
 
 /*
@@ -163,6 +175,7 @@ export const CodePreview = ({
     className,
     live = false,
     hideTitle = false,
+    ...props
 }: CodePreviewProps): React.ReactElement<any> => {
     const language = className
         ? className.replace(/language-/, '')
@@ -171,7 +184,7 @@ export const CodePreview = ({
 
     if (live) {
         return (
-            <StyledContainerElement>
+            <StyledContainerElement {...props}>
                 {!hideTitle && (
                     <Typography tag="h6" pb="3" m="0" weight={600}>
                         {title}

--- a/docs/src/components/DropDownExample/DropDownExample.component.tsx
+++ b/docs/src/components/DropDownExample/DropDownExample.component.tsx
@@ -1,0 +1,18 @@
+/**
+ * This component is used at the top of dropdown.mdx to immediately show an example of what
+ * a card looks like. This same example is given again at the bottom of the page but with the
+ * live code editor.
+ */
+
+import * as React from 'react';
+import { colors, DropDown } from '@retailmenot/anchor';
+import { MyList } from './MyList.component';
+import { MouseOverMe } from './MouseOverMe.component';
+
+export const DropDownExample = () => (
+    <DropDown overlay={<MyList />} position={{ left: 0 }}>
+        <MouseOverMe color={colors.white.base}>
+            Seriously, Mouse Over Me
+        </MouseOverMe>
+    </DropDown>
+);

--- a/docs/src/components/DropDownExample/MouseOverMe.component.tsx
+++ b/docs/src/components/DropDownExample/MouseOverMe.component.tsx
@@ -1,0 +1,15 @@
+/**
+ * This component is pulled into the CodePreview component and added to its scope. I went this route
+ * in order to pull together all the pices in the live code editor rather than just have a bunch
+ * of code samples.
+ */
+
+import * as React from 'react';
+import styled from '@xstyled/styled-components';
+import { colors, Typography } from '@retailmenot/anchor';
+
+export const MouseOverMe = styled(Typography)`
+    background-color: ${colors.savvyCyan.base};
+    width: 20rem;
+    padding: 0.5rem 1rem;
+`;

--- a/docs/src/components/DropDownExample/MyList.component.tsx
+++ b/docs/src/components/DropDownExample/MyList.component.tsx
@@ -1,0 +1,35 @@
+/**
+ * This component is pulled into the CodePreview component and added to its scope. I went this route
+ * in order to pull together all the pices in the live code editor rather than just have a bunch
+ * of code samples.
+ */
+
+import * as React from 'react';
+import styled from '@xstyled/styled-components';
+import { colors } from '@retailmenot/anchor';
+
+const StyledMyList = styled('ul')`
+    width: 100%;
+    display: block;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+        margin: 0;
+        padding: 0.5rem 2rem;
+        border-bottom: solid ${colors.savvyCyan.base} 1px;
+
+        &:last-child {
+            border-bottom-style: none;
+        }
+    }
+`;
+
+export const MyList = () => (
+    <StyledMyList>
+        <li>Not Actually A Link,</li>
+        <li>But An Example of Possibilities,</li>
+        <li>Because Anything Could be Here...</li>
+    </StyledMyList>
+);

--- a/docs/src/components/DropDownExample/index.ts
+++ b/docs/src/components/DropDownExample/index.ts
@@ -1,0 +1,3 @@
+export { DropDownExample } from './DropDownExample.component';
+export { MyList } from './MyList.component';
+export { MouseOverMe } from './MouseOverMe.component';

--- a/docs/src/pages/components/dropdown.mdx
+++ b/docs/src/pages/components/dropdown.mdx
@@ -1,2 +1,139 @@
+import { Link } from 'gatsby';
+import { DropDownExample } from './../../components/DropDownExample';
+
+<br />
+
 # DropDown
+
+The `DropDown` component provides an api to allow any component/node to have another element's
+`display` property toggle between `none` and `block` whenever it is hovered over/left. This can be
+used to create a standard DropDown menu, although it's not limited that usage.
+
+<br />
+
+<DropDownExample />
+
+<br />
+
+---
+
+## Putting it Together
+
+Since this component is designed to show/hide other components lets go ahead and make a couple of
+components to give us some styling and and a 'menu' that will appear. First, lets make the component
+that will be hovered over to show the `overlay`. This is a simple styled component that's extending
+**Anchor**'s <Link to="/components/typography/">`Typography`</Link> component to give it a little more pop.
+
+Note that we're importing **Anchor**'s `colors` object for all of the examples to follow.
+Refer to the <Link to="/theme">theme</Link> section for more information.
+
+###### MouseOverMe Component
+```jsx hideTitle
+import * as React from 'react';
+import styled from '@xstyled/styled-components';
+import { colors, Typography } from '@retailmenot/anchor';
+
+export const MouseOverMe = styled(Typography)`
+    background-color: ${colors.savvyCyan.base};
+    width: 20rem;
+    padding:0.5rem 1rem;
+`;
+```
+
+<br />
+
+Next, lets make the content for the `overlay`. This will be an unordered list with a little bit of
+styling.
+
+###### MyList Component
+```jsx hideTitle
+import * as React from 'react';
+import styled from '@xstyled/styled-components';
+import { colors} from '@retailmenot/anchor';
+
+const StyledMyList = styled('ul')`
+    width:100%;
+    display:block;
+    list-style: none;
+    margin:0;
+    padding:0;
+
+    li {
+        margin:0;
+        padding: 0.5rem 2rem;
+        border-bottom: solid ${ colors.savvyCyan.base } 1px;
+
+        &:last-child {
+            border-bottom-style:none;
+        }
+    }
+`;
+
+export const MyList = () => (
+    <StyledMyList>
+        <li>Not Actually A Link,</li>
+        <li>But An Example of Possibilities,</li>
+        <li>Because Anything Could be Here...</li>
+    </StyledMyList>
+);
+```
+
+<br />
+
+Now that we have both the component to hover over and the component to display, lets tie them
+together with `DropDown`!
+
+```jsx live
+<DropDown
+    overlay={<MyList />}
+    position={{ top:40, left: 0 }}
+>
+    <MouseOverMe color={colors.white.base}>
+        Seriously, Mouse Over Me
+    </MouseOverMe>
+</DropDown>
+```
+
+
+<br />
+
+---
+
+### API
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th width="60%">Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>overlay</td>
+            <td>
+                The overlay is the content that will be displayed when the child node is hovered
+                over. This can be a single React element, or an array of React elements.
+            </td>
+            <td>
+                React Element | Array
+            </td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td>position</td>
+            <td>
+                This positions the overlay relative to the top-left corner of the DropDown
+                component. Parameters are passed via object allowing multiple parameters to be sent,
+                i.e. &#123; top: 10, left:20 &#125;. Values are treated as pixels.
+            </td>
+            <td>Object, 'top' | 'right' | 'bottom' | 'left'</td>
+            <td>&#123; top: [outer height of DropDown], left: 0 &#125;</td>
+        </tr>
+    </tbody>
+</table>
+
+<br /><br />
 

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -43,7 +43,8 @@ const StyledDropDown = styled('div')<DropDownProps>`
     /* Position from Reference */
     .down-down-container {
         top: ${(props: any) =>
-            `${get(props, 'forwardedRef.current.clientHeight', 16)}px`}
+            `${get(props, 'forwardedRef.current.clientHeight', 16)}px`};
+    }
 `;
 
 interface DropDownContainerProps {
@@ -61,10 +62,10 @@ const StyledDropDownContainer = styled(DropDownContainer)<
     position: absolute;
     padding: 0.25rem 0;
     z-index: 1;
-    background-color: neutrals.white.base;
+    background-color: ${th.color('neutrals.white.base')};
     box-shadow: 0 0.5rem 0.5rem 0 ${th.color('neutrals.ash.base')};
     border-radius: base;
-    border: thin solid neutrals.silver.dark;
+    border: thin solid ${th.color('neutrals.silver.dark')};
     /* Defined Position */
     top: ${({ position: { top } = {} }) =>
         top ? `${top}px !important` : 'inherit'};
@@ -175,6 +176,7 @@ export class DropDown extends React.Component<DropDownProps> {
 
     render(): React.ReactElement<DropDown> {
         const { children, className, overlay, position, ...props } = this.props;
+
         return (
             <StyledDropDown
                 ref={this.dropDownReference}
@@ -183,7 +185,7 @@ export class DropDown extends React.Component<DropDownProps> {
             >
                 {children}
                 <StyledDropDownContainer
-                    className="down-down-container"
+                    className="anchor-down-down-container"
                     position={position}
                     hidden={this.state.isHidden}
                 >


### PR DESCRIPTION
fix: Used th module for styles in DropDown component

feat: added xstyled/components and xstyled/system to repo

feat: Added MyList and MouseOverMe components from DropDownExample to CodePreview's scope

feat: Added DropDownExample component and associated exports for dropdown.mdx to use

feat: Passing hideTitle to CodePreview reduces top padding

break: Added `anchor` prefix to `<StyledDropDownContainer>`'s className

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

This adds documentation and component examples for `DropDown`. 

This also fixes two bugs with the `DropDown` component: 

Border color was not applied to `StyledDropDownContainer` because the shorthand css usage breaks xstyled's mapping of values from theme. I used the `th` module in all cases where theme properties were accessed to be consistent.

Added `anchor` prefix to `<StyledDropDownContainer>`'s className. This was missing, but if anyone was using the incorrect class name in their css it will cause it to break.
