### PR TITLE
fix(build): update xstyled to 1.10.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,8 +5,8 @@
     "dependencies": {
         "@reach/component-component": "^0.1.3",
         "@retailmenot/anchor": "^0.0.1-beta.8",
-        "@xstyled/styled-components": "1.8.4",
-        "@xstyled/system": "1.8.4",
+        "@xstyled/styled-components": "1.10.0",
+        "@xstyled/system": "1.10.0",
         "babel-plugin-styled-components": "^1.10.6",
         "classnames": "^2.2.6",
         "gatsby": "^2.13.60",

--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { MDXProvider } from '@mdx-js/tag';
 import { AutoComplete } from '@retailmenot/anchor';
-import styled, { css, ThemeProvider } from '@xstyled/styled-components';
+import styled, { ThemeProvider } from '@xstyled/styled-components';
+import { css } from 'styled-components';
 // COMPONENTS
 import { fonts, NormalizeCSS } from '../../../../../src/theme';
 import { RootTheme } from '../../../../../src/theme';
@@ -32,9 +33,9 @@ const InlineCodeStyle = css`
     background-color: rgba(27, 31, 35, 0.05);
     font-family: 'SFMono-Regular', Consolas, Liberation Mono, Menlo, Courier,
         monospace;
-    border-radius: 3px;
+    border-radius: 0.1875rem;
     padding: 0.2em 0.4em;
-    font-size: 85%;
+    font-size: 0.85rem;
 `;
 
 const StyledContentMain = styled('main')`

--- a/docs/src/typings.d.ts
+++ b/docs/src/typings.d.ts
@@ -9,7 +9,14 @@ declare module '@reach/component-component' {
 }
 declare module '@retailmenot/anchor' {
   const AutoComplete: any;
+  const Badge: any;
+  const Cart: any;
+  const colors: any;
+  const Collapse: any;
+  const CollapseGroup: any;
+  const DropDown: any;
   const Search: any;
+  const Typography: any;
 }
 
 declare module '@xstyled/styled-components' {


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [ ] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

@xstyled v1.8.4 introduced a bug where one of the modules from their `utils` repo was not being pulled into their `styled-components` repo correctly. Consequently the build process was failing. The bug was later fixed in version 1.10.0.

This branch also adds a number of components to the `typings.d.ts` file under `@retailmenot/anchor`.
