### PR TITLE
docs: Updated with first round of alpha tester feedback

### DIFF
--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -6,6 +6,7 @@ import { MDXProvider } from '@mdx-js/tag';
 import { AutoComplete } from '@retailmenot/anchor';
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 import { css } from 'styled-components';
+import Helmet from 'react-helmet';
 // COMPONENTS
 import { fonts, NormalizeCSS } from '../../../../../src/theme';
 import { RootTheme } from '../../../../../src/theme';
@@ -41,6 +42,9 @@ const InlineCodeStyle = css`
 const StyledContentMain = styled('main')`
     box-sizing: border-box;
     width: 95%;
+    max-width: 80rem;
+    padding-top: 1rem;
+    padding-bottom: 3rem;
 
     table {
         width: 100%;
@@ -50,10 +54,11 @@ const StyledContentMain = styled('main')`
     th {
         text-align: left;
         padding: 0.75rem 0.5rem;
-        border-bottom: solid thin ${colors.silver.dark};
+        border-bottom: solid thin ${colors.ash.light};
+        background-color: ${colors.white.base};
     }
     tr {
-        &:nth-child(even) {
+        &:nth-child(odd) {
             background-color: ${colors.silver.light};
         }
     }
@@ -64,14 +69,20 @@ const StyledContentMain = styled('main')`
         &:first-child {
             font-family: monospace;
             color: ${colors.flashPink.dark};
+            width: 10%;
+        }
+        &:nth-child(2) {
+            width: 60%;
         }
         &:nth-child(3) {
             font-family: monospace;
             color: ${colors.cyberMango.dark};
+            width: 20%;
         }
         &:nth-child(4) {
             text-align: left;
             font-family: monospace;
+            width: 10%;
         }
 
         pre {
@@ -136,12 +147,6 @@ const CenteredCol = styled(Col)`
 // These are standard markdown styles for an inlineCode block. Can't use 'code' because that is tied
 // to the CodePreview component.
 const StyledInlineCode = styled('span')`
-    background-color: rgba(27, 31, 35, 0.05);
-    font-family: 'SFMono-Regular', Consolas, Liberation Mono, Menlo, Courier,
-        monospace;
-    border-radius: 3px;
-    padding: 0.2em 0.4em;
-    font-size: 85%;
     ${InlineCodeStyle};
 `;
 
@@ -151,6 +156,8 @@ const StyledLi = styled('li')`
 
 const StyledHr = styled('hr')`
     margin: 2rem 0;
+    color: ${colors.ash.base};
+    border-style: solid;
 `;
 
 const StyledTable = styled.table``;
@@ -267,7 +274,10 @@ export const Page = ({
 }: PageProps): React.ReactElement<any> => (
     <ThemeProvider theme={AnchorTheme}>
         <StyledPageElement className={classNames(className)}>
+            <Helmet htmlAttributes={{ lang: 'en' }} />
+
             <NormalizeCSS />
+
             <StyledHeader>
                 <Row>
                     <CenteredCol lg={2}>

--- a/docs/src/components/Utils/ColorBlurb.tsx
+++ b/docs/src/components/Utils/ColorBlurb.tsx
@@ -1,0 +1,44 @@
+/*
+    Many of the components have props for colors, and most of them have very similar descriptions
+    in the api table. This component tries to consolidate variations of those descriptions in one
+    place.
+*/
+
+import * as React from 'react';
+import { Typography } from '@retailmenot/anchor';
+import { Link } from 'gatsby';
+
+interface ColorBlurbProps {
+    /* If the text is referring to background or font color */
+    background?: boolean;
+    /* If the background accepts gradients. Should really only use this the background prop ^ */
+    gradient?: boolean;
+    /* Adds a message that the default colors come from Anchor's colors object */
+    defaultTheme?: boolean;
+    /* Specifies what component/prop the color is for. */
+    label: string;
+}
+
+export const ColorBlurb = ({
+    background,
+    gradient,
+    defaultTheme,
+    label,
+}: ColorBlurbProps): React.ReactElement<any> => (
+    <Typography>
+        Sets the {background ? 'background' : 'font'} color of the{' '}
+        <pre>{label}</pre>.
+        {defaultTheme ? (
+            <Typography pl="1">
+                It uses Anchor's <Link to="/theme">theme</Link> colors by
+                default, but any valid CSS color value can be provided
+                {background && gradient && ', including gradients'}.
+            </Typography>
+        ) : (
+            <Typography pl="1">
+                Any valid CSS color value can be provided
+                {background && gradient && ', including gradients'}.
+            </Typography>
+        )}
+    </Typography>
+);

--- a/docs/src/components/Utils/FormatTypes.component.tsx
+++ b/docs/src/components/Utils/FormatTypes.component.tsx
@@ -1,0 +1,62 @@
+/*
+    Based on https://codepen.io/impirator/pen/gVzrxW by Michael Speed Elder
+
+    Used to format the listing of all the different possible options for Types in the api sections
+    using flexbox and different colors to make the various options stand apart from each other.
+
+    Requires an array of values to iterate over. It's smart enough to render single quotes around
+    strings and no quotes around numbers. If the 'noInterpret' prop is passed, it won't make any
+    assumptions and will output exactly what is in the array without escaping content using
+    dangerouslySetInnerHTML.
+*/
+
+import * as React from 'react';
+import styled from '@xstyled/styled-components';
+import { colors } from '@retailmenot/anchor';
+
+const StyledFormatTypes = styled('div')`
+    display: flex;
+    flex-flow: row wrap;
+
+    .type:after {
+        color: ${colors.ash.base};
+        content: '|';
+        dispay: inline-block;
+        padding: 0 0.5rem;
+    }
+
+    .type:last-of-type:after {
+        content: '';
+    }
+`;
+
+interface FormatTypesProps {
+    types: [];
+    noInterpret?: boolean;
+}
+
+export const FormatTypes = ({
+    types,
+    noInterpret,
+}: FormatTypesProps): React.ReactElement<any> => (
+    <StyledFormatTypes>
+        {types.length &&
+            types.map(type => {
+                if (noInterpret) {
+                    return (
+                        <span
+                            key={type}
+                            className="type"
+                            dangerouslySetInnerHTML={{ __html: type }}
+                        />
+                    );
+                }
+
+                return (
+                    <span key={type} className="type">
+                        {typeof type === 'string' ? `'${type}'` : type}
+                    </span>
+                );
+            })}
+    </StyledFormatTypes>
+);

--- a/docs/src/components/Utils/index.ts
+++ b/docs/src/components/Utils/index.ts
@@ -1,0 +1,2 @@
+export { FormatTypes } from './FormatTypes.component';
+export { ColorBlurb } from './ColorBlurb';

--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -1,3 +1,6 @@
+import { Link } from 'gatsby';
+import { FormatTypes, ColorBlurb } from '../../components/Utils';
+
 # AutoComplete
 
 Enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering.
@@ -115,7 +118,12 @@ a key-name to use that as the display text of the result). As well, the presence
         <tr>
             <td>dataSource</td>
             <td>A collection used to render the results that should conform to the List component API</td>
-            <td>Array&lt;string&gt; | Array&lt;&#123; name: string; &#125;&gt;</td>
+            <td>
+                <FormatTypes
+                    types={['Array&lt;string&gt;', 'Array&lt;&#123; name: string; &#125;&gt;']}
+                    noInterpret
+                />
+            </td>
             <td>-</td>
         </tr>
         <tr>
@@ -127,7 +135,7 @@ a key-name to use that as the display text of the result). As well, the presence
         <tr>
             <td>size</td>
             <td>The size of the AutoComplete</td>
-            <td>'sm' | 'md' | 'lg'</td>
+            <td><FormatTypes types={['sm', 'md', 'lg']} /></td>
             <td>-</td>
         </tr>
         <tr>
@@ -151,26 +159,26 @@ a key-name to use that as the display text of the result). As well, the presence
         <tr>
             <td>border</td>
             <td>Enable/Disable the border of the AutoComplete.</td>
-            <td>Boolean</td>
+            <td>boolean</td>
             <td>true</td>
         </tr>
         <tr>
         	<td>shadow</td>
         	<td>Enable/Disable the shadow of the AutoComplete.</td>
-        	<td>Boolean</td>
+        	<td>boolean</td>
         	<td>true</td>
         </tr>
         <tr>
         	<td>background</td>
-        	<td>Set the background of the autocomplete.</td>
-        	<td>string | rgb | rgba</td>
+        	<td><ColorBlurb label="AutoComplete" /></td>
+        	<td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
         	<td>white</td>
         </tr>
         <tr>
         	<td>color</td>
-        	<td>Set the font color of the autocomplete.</td>
-        	<td>string | rgb | rgba</td>
-        	<td>Charcoal Light</td>
+        	<td><ColorBlurb defaultTheme label="AutoComplete" /></td>
+        	<td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
+        	<td><Link to="/theme">charcoal.light</Link></td>
         </tr>
         <tr>
         	<td>resultTemplate</td>
@@ -222,3 +230,5 @@ a key-name to use that as the display text of the result). As well, the presence
         </tr>
     </tbody>
 </table>
+
+<br /><br />

--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -2,6 +2,8 @@
 
 The `Avatar` component renders a generic avatar graphic, or a stylized label.
 
+<br />
+
 ```tsx live
     <section>
         <div>
@@ -18,13 +20,15 @@ The `Avatar` component renders a generic avatar graphic, or a stylized label.
 
 <br />
 
-### API
+---
+
+## API
 
 <table>
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -32,11 +36,10 @@ The `Avatar` component renders a generic avatar graphic, or a stylized label.
     <tbody>
         <tr>
             <td>label</td>
-            <td>Displays the string rather than the avatar graphic. Although any length string can
-                be provided, only the first two characters will be displayed (such as initials) and
-                also capitalized.
+            <td>Replace the default avatar graphic with the first two characters of the provided
+                string.  Letters will be automatically capitalized.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>-</td>
         </tr>
     </tbody>

--- a/docs/src/pages/components/badge.mdx
+++ b/docs/src/pages/components/badge.mdx
@@ -1,9 +1,10 @@
 import { Link } from 'gatsby';
 import { BadgeWithParentExample } from '../../components/BadgeWithParentExample';
+import { FormatTypes, ColorBlurb } from '../../components/Utils';
 
 # Badge
 
-The Badge component displays a dot or a circle with a count. It is normally used to indicate pending items (items in cart, unread messages, etc.)
+The `Badge` component displays a dot or a circle with a count. It is normally used to indicate pending items (items in cart, unread messages, etc.)
 
 ## Usage
 
@@ -131,6 +132,8 @@ export const BadgeWithParentExample = () => {
 
 <br />
 
+---
+
 ## API
 
 <table>
@@ -145,87 +148,82 @@ export const BadgeWithParentExample = () => {
     <tbody>
         <tr>
             <td>backgroundColor</td>
-            <td>The background color of the Badge</td>
-            <td>string | hex code | rgb</td>
-            <td>'error'</td>
+            <td><ColorBlurb background label="Badge" /></td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
+            <td>error</td>
         </tr>
         <tr>
             <td>borderColor</td>
-            <td>The color of the border of the Badge</td>
-            <td>string | hex code | rgb</td>
-            <td>'error'</td>
+            <td>The color of the border of the <pre>Badge</pre></td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
+            <td>error</td>
         </tr>
         <tr>
             <td>borderColorHover</td>
-            <td>The color of the border of the Badge on hover</td>
-            <td>string | hex code | rgb</td>
-            <td>'error'</td>
+            <td>The color of the border of the <pre>Badge</pre> on hover</td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
+            <td>error</td>
         </tr>
         <tr>
             <td>children</td>
-            <td>Any elements inside the Badge tags. This is what we use to pass Icon components in.</td>
+            <td>Any elements inside the <pre>Badge</pre> tags. This is what we use to pass <Link to="/components/icon">Icon</Link> components
+                in.</td>
             <td>Icon</td>
             <td>-</td>
         </tr>
         <tr>
-            <td>className</td>
-            <td>Additional className to be added to the Badge element</td>
-            <td>string</td>
-            <td>-</td>
-        </tr>
-        <tr>
             <td>count</td>
-            <td>The number to be displayed inside the badge</td>
+            <td>The number to be displayed inside the <pre>Badge</pre></td>
             <td>number</td>
             <td>0</td>
         </tr>
         <tr>
             <td>isParentHovered</td>
-            <td>Whether the parent element of the Badge is hovered</td>
+            <td>Whether the parent element of the <pre>Badge</pre> is hovered</td>
             <td>boolean</td>
             <td>false</td>
         </tr>
         <tr>
             <td>overflowCount</td>
-            <td>The maximum count to show in the Badge</td>
+            <td>The maximum count to show in the <pre>Badge</pre></td>
             <td>number</td>
             <td>9</td>
         </tr>
         <tr>
             <td>offsetBottom</td>
-            <td>The absolute positioning in REM from the bottom</td>
+            <td>The absolute positioning in <pre>rem</pre> from the bottom</td>
             <td>number</td>
             <td>-</td>
         </tr>
         <tr>
             <td>offsetLeft</td>
-            <td>The absolute positioning in REM from the left</td>
+            <td>The absolute positioning in <pre>rem</pre> from the left</td>
             <td>number</td>
             <td>-</td>
         </tr>
         <tr>
             <td>showZero</td>
-            <td>Whether to show the badge if the `count` is 0</td>
+            <td>Whether to show the badge if the <pre>count</pre> is <pre>0</pre>.</td>
             <td>boolean</td>
             <td>false</td>
         </tr>
         <tr>
             <td>size</td>
-            <td>The size of the badge</td>
-            <td>'dot' | 'small' | 'large'</td>
-            <td>'dot'</td>
+            <td>The size of the <pre>Badge</pre>.</td>
+            <td><FormatTypes types={['dot', 'small', 'large']} /></td>
+            <td>dot</td>
         </tr>
         <tr>
             <td>standalone</td>
-            <td>Whether the Badge will be displayed alone</td>
+            <td>Whether the <pre>Badge</pre> will be displayed alone.</td>
             <td>boolean</td>
             <td>false</td>
         </tr>
         <tr>
             <td>textColor</td>
-            <td>The color of the text of the `count`</td>
-            <td>string | hex code | rgb</td>
-            <td>'neutrals.white.base'</td>
+            <td><ColorBlurb defaultTheme label="count" /></td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
+            <td><Link to="/theme">white.base</Link></td>
         </tr>
     </tbody>
 </table>

--- a/docs/src/pages/components/card.mdx
+++ b/docs/src/pages/components/card.mdx
@@ -1,5 +1,6 @@
 import { Link } from 'gatsby';
 import { CardExample } from '../../components/CardExample';
+import { FormatTypes } from '../../components/Utils';
 
 # Card
 
@@ -34,17 +35,17 @@ const StyledMoreInfo = styled(InfoOutline)`
         cursor:pointer;
 
         &:after {
-            content:'I am an Action';
-            display:block;
-            padding:1rem;
+            content: 'I am an Action';
+            display: block;
+            padding: 1rem;
             background-color: ${colors.success.dark};
             color: ${colors.white.base};
-            position:absolute;
-            right:1.75rem;
-            white-space:nowrap;
-            top:0;
-            z-index:1000;
-            border-radius:0.25rem;
+            position: absolute;
+            right: 1.75rem;
+            white-space: nowrap;
+            top: 0;
+            z-index: 1000;
+            border-radius: 0.25rem;
         }
     }
 `;
@@ -69,8 +70,8 @@ import { colors, Typography } from '@retailmenot/anchor';
 
 const StyledBottomArea = styled('div')`
     background-color: ${colors.silver.base};
-    color:${colors.charcoal.base};
-    padding:1rem;
+    color: ${colors.charcoal.base};
+    padding: 1rem;
 `;
 
 export const BottomArea = () => (
@@ -107,13 +108,13 @@ Now that we've created these separate components, lets organize them into a `Car
 
 ---
 
-### API
+## API
 
 <table>
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -124,10 +125,10 @@ Now that we've created these separate components, lets organize them into a `Car
             <td>
                 Although this prop will accept any value, it makes the most sense to pass a
                 component. It will absolutely position this component in the upper-right corner of
-                the card and is unaffected by the gutter prop.
+                the <pre>Card</pre> and is unaffected by the <pre>gutter</pre> prop.
             </td>
             <td>
-                Any
+                any
             </td>
             <td>-</td>
         </tr>
@@ -135,21 +136,19 @@ Now that we've created these separate components, lets organize them into a `Car
             <td>actionArea</td>
             <td>
                 Although this prop will accept any value, it makes the most sense to pass a
-                component. It will be placed flush against the bottom of the card and will be
-                unaffected by the gutter prop.
+                component. It will be placed flush against the bottom of the <pre>Card</pre> and will
+                be unaffected by the <pre>gutter</pre> prop.
             </td>
-            <td>Any</td>
+            <td>any</td>
             <td>-</td>
         </tr>
         <tr>
             <td>gutter</td>
             <td>
-                The padding of the card's content.
+                The padding of the <pre>Card</pre>'s content.
             </td>
-            <td>'none' | 'small' | 'medium' | 'large'</td>
+            <td><FormatTypes types={['none', 'small', 'medium', 'large']} /></td>
             <td>medium</td>
         </tr>
     </tbody>
 </table>
-
-<br /><br />

--- a/docs/src/pages/components/collapse.mdx
+++ b/docs/src/pages/components/collapse.mdx
@@ -1,13 +1,16 @@
 import { Link } from 'gatsby';
+import { FormatTypes } from '../../components/Utils';
 
 # Collapse
 
-The Collapse component allows a user to click on a button and toggle the rendering of its child.
+The `Collapse` component allows a user to click on a button and toggle the rendering of its child.
 This site uses this component and the `CollapseGroup` component for its side navigation. Note that it
 does not simply show/hide content, it re-renders it.
 
-When using the **Live Code Editor**, you can use any <Link to="/components/icon">Icon component</Link>
+When using the **Live Code Editor**, you can use any <Link to="/components/icon">Icon</Link> component
 available in **Anchor** for the `openedIcon` and `closedIcon` props.
+
+<br />
 
 ```tsx live
 <Collapse
@@ -26,6 +29,8 @@ available in **Anchor** for the `openedIcon` and `closedIcon` props.
 ## CollapseGroup
 
 The **`CollapseGroup`** component combines multiple **`Collapse`** components together, allowing a single component to apply props to all children, unifying their appearance, and adding the ability to have accordion functionality.
+
+<br />
 
 ```tsx live
 <CollapseGroup
@@ -75,19 +80,21 @@ The **`CollapseGroup`** component combines multiple **`Collapse`** components to
         <tr>
             <td>closedText</td>
             <td>The text that appears on the button as a CTA when the component is closed.</td>
-            <td>String</td>
+            <td>string</td>
             <td>Open</td>
         </tr>
         <tr>
             <td>hasBottomBorder</td>
             <td>Shows/hides the bottom border.</td>
-            <td>Boolean</td>
+            <td>boolean</td>
             <td>true</td>
         </tr>
         <tr>
             <td>isOpen</td>
-            <td>Determines whether the Collapse component is open or not. Changing the value of this prop will programatticaly open/close the component, thusly not requiring a click event.</td>
-            <td>Boolean</td>
+            <td>Determines whether the <pre>Collapse</pre> component is open or not. Changing the
+                value of this prop will programatticaly open/close the component, thusly not
+                requiring a click event.</td>
+            <td>boolean</td>
             <td>false</td>
         </tr>
         <tr>
@@ -99,15 +106,15 @@ The **`CollapseGroup`** component combines multiple **`Collapse`** components to
         <tr>
             <td>openedText</td>
             <td>The text that appears on the button as a CTA when the component is opened.</td>
-            <td>String</td>
+            <td>string</td>
             <td>Close</td>
         </tr>
         <tr>
             <td>variant</td>
-            <td>Several variants of collapse. Comfortable has considerable spacing, compact has
-                much tighter spacing, and none removes all styling.
+            <td>Several variants of collapse. <pre>comfortable</pre> has considerable spacing,
+                <pre>compact</pre> has much tighter spacing, and <pre>none</pre> removes all styling.
             </td>
-            <td>'comfortable' | 'compact' | 'none'</td>
+            <td><FormatTypes types={['comfortable', 'compact', 'none']} /></td>
             <td>comfortable</td>
         </tr>
     </tbody>
@@ -121,7 +128,7 @@ The **`CollapseGroup`** component combines multiple **`Collapse`** components to
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -129,40 +136,39 @@ The **`CollapseGroup`** component combines multiple **`Collapse`** components to
     <tbody>
         <tr>
             <td>accordion</td>
-            <td>Enables accordion functionality, where only one Collapse component can be open at a time.</td>
-            <td>Boolean</td>
+            <td>Enables accordion functionality, where only one <pre>Collapse</pre> component can be
+                open at a time.</td>
+            <td>boolean</td>
             <td>false</td>
         </tr>
         <tr>
             <td>closedIcon</td>
-            <td>Using this prop will apply the setting to all child Collapse components. Otherwise
-                its functionality is as noted above for Collapse.
+            <td>Using this prop will apply the setting to all child <pre>Collapse</pre> components.
+                Otherwise its functionality is as noted above for <pre>Collapse</pre>.
             </td>
             <td>ReactElement</td>
             <td>-</td>
         </tr>
         <tr>
             <td>openedIcon</td>
-            <td>Using this prop will apply the setting to all child Collapse components. Otherwise
-                its functionality is as noted above for Collapse.</td>
+            <td>Using this prop will apply the setting to all child <pre>Collapse</pre> components.
+                Otherwise its functionality is as noted above for <pre>Collapse</pre>.</td>
             <td>ReactElement</td>
             <td>-</td>
         </tr>
         <tr>
             <td>openIndex</td>
-            <td>If accordion is set to true, this determines which Collapse component will start in
-                the open state based on index.</td>
-            <td>Number</td>
+            <td>If <pre>accordion</pre> is set to true, this determines which <pre>Collapse</pre>
+                component will start in the open state based on index.</td>
+            <td>number</td>
             <td>0</td>
         </tr>
         <tr>
             <td>variant</td>
             <td>Using this prop will apply the setting to all child Collapse components. Otherwise
-                its functionality is as noted above for Collapse.</td>
-            <td>'comfortable' | 'compact' | 'none'</td>
+                its functionality is as noted above for <pre>Collapse</pre>.</td>
+            <td><FormatTypes types={['comfortable', 'compact', 'none']} /></td>
             <td>-</td>
         </tr>
     </tbody>
 </table>
-
-<br /><br />

--- a/docs/src/pages/components/dropdown.mdx
+++ b/docs/src/pages/components/dropdown.mdx
@@ -1,5 +1,6 @@
 import { Link } from 'gatsby';
 import { DropDownExample } from './../../components/DropDownExample';
+import { FormatTypes } from '../../components/Utils';
 
 <br />
 
@@ -99,13 +100,13 @@ together with `DropDown`!
 
 ---
 
-### API
+## API
 
 <table>
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -114,7 +115,7 @@ together with `DropDown`!
         <tr>
             <td>overlay</td>
             <td>
-                The overlay is the content that will be displayed when the child node is hovered
+                The content that will be displayed when the child node is hovered
                 over. This can be a single React element, or an array of React elements.
             </td>
             <td>
@@ -125,15 +126,12 @@ together with `DropDown`!
         <tr>
             <td>position</td>
             <td>
-                This positions the overlay relative to the top-left corner of the DropDown
+                This positions the overlay relative to the top-left corner of the <pre>DropDown</pre>
                 component. Parameters are passed via object allowing multiple parameters to be sent,
-                i.e. &#123; top: 10, left:20 &#125;. Values are treated as pixels.
+                i.e. <pre>&#123; top: 10, left: 20 &#125;</pre>. Values are treated as <pre>px</pre>.
             </td>
-            <td>Object, 'top' | 'right' | 'bottom' | 'left'</td>
+            <td>object, <FormatTypes types={['top', 'right', 'bottom', 'left']} /></td>
             <td>&#123; top: [outer height of DropDown], left: 0 &#125;</td>
         </tr>
     </tbody>
 </table>
-
-<br /><br />
-

--- a/docs/src/pages/components/hero.mdx
+++ b/docs/src/pages/components/hero.mdx
@@ -1,4 +1,5 @@
 import { Link } from 'gatsby';
+import { FormatTypes, ColorBlurb } from '../../components/Utils';
 
 # Hero
 
@@ -19,8 +20,13 @@ Depending on how your environment is set up, you could directly access these sub
 in your jsx as shown below. This example uses the `colors` export from **Anchor** which is the basis for <Link to="/theme">themes</Link>,
 as well as the <Link to="/components/button/">`Button`</Link> component.
 
+<br />
+
 ```tsx live
-    <Hero background={colors.grapePurchase.base} minHeight="12.5rem">
+    <Hero
+        background={colors.grapePurchase.base}
+        minHeight="12.5rem"
+    >
         <Hero.Title weight="bolder">TITLE!</Hero.Title>
 
         <Hero.Subtitle scale="16">SUBTITLE!</Hero.Subtitle>
@@ -49,7 +55,7 @@ as well as the <Link to="/components/button/">`Button`</Link> component.
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -58,42 +64,41 @@ as well as the <Link to="/components/button/">`Button`</Link> component.
         <tr>
             <td>align</td>
             <td>
-                The alignment of content within the Hero.
+                The alignment of content within the <pre>Hero</pre>.
             </td>
             <td>
-                'center' | 'left' | 'right' | 'inherit' | 'justify'
+                <FormatTypes types={['center', 'left', 'right', 'inherit', 'justify']} />
             </td>
             <td>center</td>
         </tr>
         <tr>
             <td>background</td>
             <td>
-                Sets the background color of the Hero. Any valid css color value
-                (including gradients) can be used.
+                <ColorBlurb background gradient label="Hero" />
             </td>
             <td>
-                String
+                <FormatTypes types={['string', 'rgb', 'rgba']} noInterpret />
             </td>
             <td>transparent</td>
         </tr>
         <tr>
             <td>color</td>
             <td>
-                Sets the font color of the Hero. It uses Anchor's <Link to="/theme">theme</Link> colors
-                by default, but any valid css color value can be used.
+                <ColorBlurb defaultTheme label="Hero" />
             </td>
             <td>
-                String
+                <FormatTypes types={['string', 'rgb', 'rgba']} noInterpret />
             </td>
-            <td>white.base</td>
+            <td><Link to="/theme">white.base</Link></td>
         </tr>
         <tr>
             <td>minHeight</td>
             <td>
-                The minimum height that the Hero should be rendered at.
+                The minimum height that the Hero should be rendered at. This accepts any valid CSS
+                unit of measurement (<pre>px</pre>, <pre>%</pre>, <pre>rem</pre>, etc).
             </td>
             <td>
-                String
+                string
             </td>
             <td>7.5rem</td>
         </tr>
@@ -105,14 +110,14 @@ as well as the <Link to="/components/button/">`Button`</Link> component.
 ### Title
 
 `Title` is as a wrapper of the `Typography` component.
-Editable props are `tag`  and `weight`. Refer to `Typography`'s <Link to="/components/typography">documentation</Link> for
+Editable props are `tag`  and `weight`. Refer to <Link to="/components/typography">`Typography`</Link> for
 more information.
 
 <table>
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -121,8 +126,9 @@ more information.
         <tr>
             <td>scale</td>
             <td>
-                Note that the default tag that is used, 'h1', will prevent scale from working. Any
-                Typography 'tag' using a heading has this limitation (h1, h2, h3, h4, h5, h6).
+                Note that the default tag that is used, <pre>h1</pre>, will prevent scale from working. Any
+                <pre>Typography</pre> <pre>tag</pre> using a heading has this limitation
+                (<pre>h1</pre>, <pre>h2</pre>, <pre>h3</pre>, <pre>h4</pre>, <pre>h5</pre>, <pre>h6</pre>).
             </td>
             <td>
                 -
@@ -163,7 +169,7 @@ Refer to `Typography`'s <Link to="/components/typography">documentation</Link> f
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -191,5 +197,3 @@ Refer to `Typography`'s <Link to="/components/typography">documentation</Link> f
         </tr>
     </tbody>
 </table>
-
-<br /><br />

--- a/docs/src/pages/components/icon.mdx
+++ b/docs/src/pages/components/icon.mdx
@@ -1,11 +1,12 @@
 import { IconList, IconCount, IconTextList } from '../../components/IconList';
 import { Collapse } from '@retailmenot/anchor';
+import { FormatTypes } from '../../components/Utils';
 
 # Icon
 
 All of the icons are `svg`'s, and can be colored and scaled as needed. **Anchor** does not group all
 of the icons together, rather they are individually imported in order to keep the bundle size small.
-All icons are rendered individually by their name, i.e. **`ArrowBack`** or **`Expand`**, as shown below.
+All icons are rendered individually by their name, i.e. `ArrowBack` or `Expand`, as shown below.
 
 #### Available Icons
 
@@ -20,7 +21,7 @@ There are currently <IconCount /> icons available. Note that you can try any of 
 ```tsx live
 <section>
     <div>
-        <Star color="red" />
+        <Star color={colors.savvyCyan.base} />
     </div>
 
     <div>
@@ -31,12 +32,41 @@ There are currently <IconCount /> icons available. Note that you can try any of 
 
 <br />
 
-### Props
+---
 
-* `color`: Defaults to **`currentColor`**, a SVG color property that will allow the icon to inherit its parent color.
-However, if a value is passed it will take whatever hex/rgb/rgba value provided.
-* `scale`: Defaults to **`md`**, which translates to 16px by 16px. The full range of options are **`'xs', 'sm', 'md', 'lg', 'xl', 'xxl'`**
-* `className`: An additional class name. All icons have the **`anchor-icon`** class name in addition to a more specific class.
-Ex: **`class="anchor-icon arrow-back"`**.
+## API
 
-<br /><br />
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>color</td>
+            <td>
+                The color of the icon. Accepts any valid CSS color proprty. It's default value,
+                <pre>currentColor</pre>, is an SVG property that will allow the icon to inherit its
+                parent color.
+            </td>
+            <td>
+                <FormatTypes types={['string', 'rgb', 'rgba']} noInterpret />
+            </td>
+            <td>currentColor</td>
+        </tr>
+        <tr>
+            <td>scale</td>
+            <td>
+                The scale/size of the icon. Enumerated values are in <pre>px</pre> and are as
+                follows: <pre>xs: 8</pre>, <pre>sm: 14</pre>, <pre>md: 16</pre>, <pre>lg: 24</pre>,
+                <pre>xl: 32</pre>, <pre>xxl: 48</pre>.
+            </td>
+            <td><FormatTypes types={['xs', 'sm', 'md', 'lg', 'xl', 'xxl']} /></td>
+            <td>md</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/src/pages/components/menu.mdx
+++ b/docs/src/pages/components/menu.mdx
@@ -1,12 +1,13 @@
 import { Link } from 'gatsby';
 import { CardExample } from '../../components/CardExample';
+import { FormatTypes, ColorBlurb } from '../../components/Utils';
 
 <br />
 
 # Menu
 
 The `Menu` component pulls together links into a single horizontal menu bar with unified styling. It
-is composed of two components, `Menu` itself, and its child elements, `MenuItem`. `MenuItem` is a
+is composed of two components: `Menu` and `MenuItem`. `MenuItem` is a
 wrapper for the `a` tag, so any valid attribute for that element will be applied.
 
 ```tsx live
@@ -34,7 +35,7 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -43,29 +44,28 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
         <tr>
             <td>background</td>
             <td>
-                Sets the background color of the <pre>Menu</pre>. Any valid css color value can be
-                used (including gradients).
+                <ColorBlurb background gradient label="Menu" />
             </td>
             <td>
-                String
+                <FormatTypes types={['string', 'rgb', 'rgba']} noInterpret />
             </td>
-            <td>primary.base</td>
+            <td><Link to="/theme">primary.base</Link></td>
         </tr>
         <tr>
             <td>color</td>
             <td>
-                Sets the text color of the <pre>Menu</pre>. Any valid css color value can be used.
+                <ColorBlurb label="Menu" />
             </td>
-            <td>String</td>
-            <td>white.base</td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
+            <td><Link to="/theme">white.base</Link></td>
         </tr>
         <tr>
             <td>justify</td>
             <td>
-                Using css flexbox, aligns the menu items either to the left (<pre>flex-start</pre>)
+                Using CSS flexbox, aligns the menu items either to the left (<pre>flex-start</pre>)
                 or right (<pre>flex-end</pre>).
             </td>
-            <td>'flex-start' | 'flex-end'</td>
+            <td><FormatTypes types={['flex-start', 'flex-end']} /></td>
             <td>flex-start</td>
         </tr>
         <tr>
@@ -73,7 +73,7 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
             <td>
                 Alters the padding around the menu items, as well as their font weight and size.
             </td>
-            <td>'small' | 'large'</td>
+            <td><FormatTypes types={['small', 'large']} /></td>
             <td>large</td>
         </tr>
     </tbody>
@@ -87,7 +87,7 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -101,7 +101,7 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
                 'active', giving the user full control.
             </td>
             <td>
-                Boolean
+                boolean
             </td>
             <td>-</td>
         </tr>
@@ -112,7 +112,7 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
                 <pre>div</pre>, <pre>span</pre>, etc. Note that this will affect styling of the
                 <pre>MenuItem</pre>
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>-</td>
         </tr>
         <tr>
@@ -120,7 +120,7 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
             <td>
                 The text for the generated link.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>-</td>
         </tr>
         <tr>
@@ -129,10 +129,8 @@ wrapper for the `a` tag, so any valid attribute for that element will be applied
                 Specifies the <a href="http://www.htmlquick.com/reference/mime-types.html" target="_blank">internet media type</a> of
                 the linked document.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>-</td>
         </tr>
     </tbody>
 </table>
-
-<br /><br />

--- a/docs/src/pages/components/modal.mdx
+++ b/docs/src/pages/components/modal.mdx
@@ -1,10 +1,11 @@
 import { Link } from 'gatsby';
 import { Typography } from '@retailmenot/anchor';
 import { ModalExample } from '../../components/ModalExample';
+import { FormatTypes, ColorBlurb } from '../../components/Utils';
 
 # Modal
 
-The Modal component is an overlay over all content on the page, presenting its own content area
+The `Modal` component is an overlay over all content on the page, presenting its own content area
 for the user to interact with. Here is an example of the modal:
 
 <br />
@@ -38,7 +39,7 @@ functionality. A function to close the modal will have to be assigned as an `onC
 show up in the modal. It has no props and serves only to correctly position the content within the
 modal. Content has a set amount of padding on all sides, however it will lose its top padding if
 used with `Header`, and it will lose it's bottom padding if used with `Footer`.
-* `RootTheme` provides a number of css styles that the modal will use.
+* `RootTheme` provides a number of CSS styles that the modal will use.
 * `ModalProvider` will set the root portal where `Modal`s will be rendered.
 * `ThemeProvider` comes from the <a href="https://www.styled-components.com/" target="_blank">`styled-components`</a> library
 and will apply the `RootTheme` to the modal.
@@ -198,7 +199,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -207,29 +208,27 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
         <tr>
             <td>background</td>
             <td>
-                Sets the background color of the modal. It uses Anchor's <Link to="/theme">theme</Link> colors
-                by default, but any color value can be provided.
+                <ColorBlurb background gradient defaultTheme label="Modal" />
             </td>
             <td>
-                String
+                <FormatTypes types={['string', 'rgb', 'rgba']} noInterpret />
             </td>
-            <td>white.base</td>
+            <td><Link to="/theme">white.base</Link></td>
         </tr>
         <tr>
             <td>color</td>
             <td>
-                Sets the font color of the modal. It uses Anchor's <Link to="/theme">theme</Link> colors
-                by default, but any color value can be provided.
+                <ColorBlurb defaultTheme label="Modal" />
             </td>
-            <td>String</td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
             <td>-</td>
         </tr>
         <tr>
             <td>height</td>
             <td>
-                A specific height of the modal. Accepts any standard css unit, i.e. 500px, 50%, etc.
+                A specific height of the modal. Accepts any standard CSS unit, i.e. 500px, 50%, etc.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>42.375rem</td>
         </tr>
         <tr>
@@ -239,7 +238,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
                 unless you do not want the modal centered. Accepts any standard margin shorthand
                 value, i.e. '5px 10px 8px'.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>auto</td>
         </tr>
         <tr>
@@ -248,8 +247,8 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
                 Applies a box-shadow to the Modal container. Accepts any standard box-shadow shorthand
                 value.
             </td>
-            <td>String</td>
-            <td>0 0.375rem 0.5rem 0.25rem rgba(0,0,0,0.13)</td>
+            <td>string</td>
+            <td><pre>0 0.375rem 0.5rem 0.25rem rgba(0,0,0,0.13)</pre></td>
         </tr>
         <tr>
             <td>size</td>
@@ -257,17 +256,17 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
                 Changes the size of the modal.
             </td>
             <td>
-                'lg' | 'sm'
+                <FormatTypes types={['lg', 'sm']} />
             </td>
-            <td>'lg'</td>
+            <td>lg</td>
         </tr>
         <tr>
             <td>width</td>
             <td>
-                A specific width of the modal. Accepts any standard css unit, i.e. 500px, 50%, etc.
+                A specific width of the modal. Accepts any standard CSS unit, i.e. 500px, 50%, etc.
                 If no width is specified, the size is used instead.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>-</td>
         </tr>
     </tbody>
@@ -281,7 +280,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -290,22 +289,20 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
         <tr>
             <td>background</td>
             <td>
-                Sets the background color of the header. It uses Anchor's <Link to="/theme">theme</Link> colors
-                by default, but any color value can be provided.
+                <ColorBlurb defaultTheme background label="Header" />
             </td>
             <td>
-                String
+                <FormatTypes types={['string', 'rgb', 'rgba']} noInterpret />
             </td>
-            <td>white.base</td>
+            <td><Link to="/theme">white.base</Link></td>
         </tr>
         <tr>
             <td>color</td>
             <td>
-                Sets the font color of the title. It uses Anchor's <Link to="/theme">theme</Link> colors
-                by default, but any color value can be provided.
+                <ColorBlurb defaultTheme label="header" />
             </td>
-            <td>String</td>
-            <td>charcoal.light</td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
+            <td><Link to="/theme">charcoal.light</Link></td>
         </tr>
         <tr>
             <td>title</td>
@@ -313,7 +310,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
                 Renders the supplied text with Anchor's <Link to="/components/typography">Typography</Link> component with a scale of
                 20 and a weight of bold.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>-</td>
         </tr>
     </tbody>
@@ -327,7 +324,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -336,19 +333,20 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
         <tr>
             <td>background</td>
             <td>
-                Sets the background color of the footer.
+                <ColorBlurb background label="Footer" />
             </td>
             <td>
-                String
+                <FormatTypes types={['string', 'rgb', 'rgba']} noInterpret />
             </td>
             <td>transparent</td>
         </tr>
         <tr>
             <td>padding</td>
             <td>
-                Sets the padding for the footer.
+                Sets the padding for the footer. Any valid css padding shorthand is accepted, ex:
+                <pre>1rem</pre>, or <pre>1rem 32px</pre>, etc.
             </td>
-            <td>String</td>
+            <td>string</td>
             <td>-</td>
         </tr>
     </tbody>
@@ -362,7 +360,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -373,10 +371,8 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
             <td>
                 Aligns the close button to the left or right corner of its parent element.
             </td>
-            <td>'right' | 'left'</td>
+            <td><FormatTypes types={['right', 'left']} /></td>
             <td>-</td>
         </tr>
     </tbody>
 </table>
-
-<br /><br />

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -1,9 +1,10 @@
 import { Link } from 'gatsby';
+import { FormatTypes } from '../../components/Utils';
 
 # Typography
 
 The `Typography` component lets you easily add unified text styles to the page without having to create
-a lot of extra css.
+a lot of extra CSS.
 
 One of the principal features of this component is the concept of **`scale`**.
 Although it's possible to alter the `line-height` (`lineHeight` prop) and `font-size` (`size` prop)
@@ -21,6 +22,8 @@ These are the default styles for Typography:
 * `text-transform: none;`
 * `color: inherit;`
 
+<br />
+
 ```tsx live
 <div>
     <Typography tag="p">
@@ -37,13 +40,15 @@ These are the default styles for Typography:
 
 <br />
 
+---
+
 ## API
 
 <table>
     <thead>
         <tr>
             <th>Property</th>
-            <th width="60%">Description</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
         </tr>
@@ -53,95 +58,102 @@ These are the default styles for Typography:
             <td>align</td>
             <td>
                 Changes the alignment of text within the component.
-                As this is the application of a css property, standard css rules apply.
+                As this is the application of a CSS property, standard CSS rules apply.
             </td>
-            <td>'center' | 'left' | 'right' | 'inherit' | 'justify'</td>
+            <td>
+                <FormatTypes types={['center', 'left', 'right', 'inherit', 'justify']} />
+            </td>
             <td>inherit</td>
         </tr>
         <tr>
             <td>color</td>
             <td>
-                Takes a color value, either via hex code or by name. If
-                you use one of Anchor's <Link to="/theme">theme</Link> colors, you'll be able to
-                control its hue via a prop noted below.
+                Sets the font color. Accepts any valid CSS color value. If
+                you use one of <strong>Anchor</strong>'s <Link to="/theme">theme</Link> colors,
+                you'll be able to control its hue via a prop noted below.
             </td>
-            <td>String</td>
+            <td><FormatTypes types={['string', 'rgb', 'rgba']} noInterpret /></td>
             <td>inherit</td>
         </tr>
         <tr>
             <td>display</td>
             <td>
-                Controls the css display property of the tag.
+                Controls the CSS <pre>display</pre> property of the tag.
             </td>
             <td>
-                'inline' | 'block' | 'contents' | 'flex' | 'grid' | 'inline-block' | 'inline-flex' |
-                'inline-grid' | 'inline-table' | 'list-item' | 'run-in' | 'table' | 'table-caption'
-                | 'table-column-group' | 'table-header-group' | 'table-footer-group' |
-                'table-row-group' | 'table-cell' | 'table-column' | 'table-row' | 'none' |
-                'initial' | `inherit`
+                <FormatTypes types={['inline', 'block', 'contents', 'flex', 'grid', 'inline-block',
+                    'inline-flex', 'inline-grid', 'inline-table', 'list-item', 'run-in', 'table',
+                    'table-caption', 'table-column-group', 'table-header-group',
+                    'table-footer-group', 'table-row-group', 'table-cell', 'table-column',
+                    'table-row', 'none', 'initial', 'inherit']}
+                />
             </td>
             <td>-</td>
         </tr>
         <tr>
             <td>href</td>
             <td>
-                When used in conjunction with setting the tag prop to a, creates a link to the
-                specified page/resource.
+                When used in conjunction with setting the <pre>tag</pre> prop to <pre>a</pre>,
+                creates a link to the specified page/resource.
             </td>
             <td>
-                String
+                string
             </td>
             <td>-</td>
         </tr>
         <tr>
             <td>htmlFor</td>
             <td>
-                When used in conjuction setting the tag prop to label, adds the <a href="https://www.w3schools.com/tags/att_for.asp" target="_blank">for</a> html
+                When used in conjuction setting the <pre>tag</pre> prop to <pre>label</pre>, adds
+                the <pre><a href="https://www.w3schools.com/tags/att_for.asp" target="_blank">for</a></pre> html
                 attribute in order to associate the label to a form element.
             </td>
             <td>
-                String
+                string
             </td>
             <td>-</td>
         </tr>
         <tr>
             <td>hue</td>
             <td>
-                If the color prop is set to one of Anchor's <Link to="/theme">theme</Link> colors,
+                If the <pre>color</pre> prop is set to one of <strong>Anchor</strong>'s <Link to="/theme">theme</Link> colors,
                 allows changing that color's hue.
             </td>
             <td>
-                'light' | 'base' | 'dark'
+                <FormatTypes types={['light', 'base', 'dark']} />
             </td>
             <td>-</td>
         </tr>
         <tr>
             <td>lineHeight</td>
             <td>
-                Changes the line-height css property. It is not recommended to edit this value, as
-                the scale prop will adjust both size and lineHeight accordingly.
+                Changes the <pre>line-height</pre> CSS property. It is not recommended to edit this
+                value, as the <pre>scale</pre> prop will adjust both <pre>size</pre> and <pre>lineHeight</pre> accordingly.
+                This value is in <pre>px</pre>.
             </td>
             <td>
-                Number
+                number
             </td>
             <td>-</td>
         </tr>
         <tr>
             <td>scale</td>
             <td>
-                This value directly affects the size and lineHeight props directly, ensuring
-                that there is no overlap of text between lines no matter what value is input.
+                This value directly affects the <pre>size</pre> and <pre>lineHeight</pre> props
+                directly, ensuring that there is no overlap of text between lines no matter what
+                value is input. This value is in <pre>px</pre>.
             </td>
             <td>
-                62 | 52 | 44 | 36 | 32 | 28 | 24 | 20 | 18 | 16 | 14 | 12
+                <FormatTypes types={[62 , 52 , 44 , 36 , 32 , 28 , 24 , 20 , 18 , 16 , 14 , 12]} />
             </td>
             <td>16</td>
         </tr>
         <tr>
             <td>size</td>
             <td>
-                Changes the font-size css property. It is not recommended to edit this value,
-                as the scale prop will adjust both size and lineHeight accordingly.
+                Changes the <pre>font-size</pre> CSS property. It is not recommended to edit this
+                value, as the scale prop will adjust both <pre>size</pre> and <pre>lineHeight</pre> accordingly.
+                This value is in <pre>px</pre>.
             </td>
             <td>
                 -
@@ -154,33 +166,36 @@ These are the default styles for Typography:
                 Changing this prop will let the component render as the specified html tag.
             </td>
             <td>
-                'a' | 'p' | 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote' |
-                'address' | 'code' | 'label' | 'pre'
+                <FormatTypes types={['a', 'p', 'span', 'h1', 'h2', 'h3', 'h4', 'h5',
+                    'h6', 'blockquote', 'address', 'code', 'label', 'pre']}
+                />
             </td>
-            <td>'span'</td>
+            <td>span</td>
         </tr>
         <tr>
             <td>transform</td>
             <td>
-                Changes the text-transform css property.
+                Changes the <pre>text-transform</pre> CSS property.
             </td>
             <td>
-                'none' | 'capitalize' | 'uppercase' | 'lowercase' | 'initial' | 'inherit'
+                <FormatTypes types={['none', 'capitalize', 'uppercase', 'lowercase',
+                    'initial', 'inherit']}
+                />
             </td>
-            <td>'none'</td>
+            <td>none</td>
         </tr>
         <tr>
             <td>weight</td>
             <td>
-                Changes the font-weight css property.
+                Changes the <pre>font-weight</pre> CSS property.
             </td>
             <td>
-                'normal' | 'bold' | 'bolder' | 'lighter' | '100' | '200' | '300' | '400' | '500' | '600' |
-                '700' | '800' | '900' | 'initial' | 'inherit'
+                <FormatTypes types={[
+                    'normal' , 'bold' , 'bolder' , 'lighter' , '100' , '200' , '300' ,
+                    '400' , '500' , '600' , '700' , '800' , '900' , 'initial' , 'inherit'
+                ]} />
             </td>
-            <td>'none'</td>
+            <td>none</td>
         </tr>
     </tbody>
 </table>
-
-<br /><br />


### PR DESCRIPTION
docs(Page): Set a max width for StyledContentMain

docs(Page): slightly changed coloring of tables

chore(Page): removed duplicated code for StyledInlineCode

docs(Page): Updated StyledHr's color

docs: made all variable types lowercase

docs: added pre tags around all code-related text

docs: All API sections now begin with an h2 tag

docs(icon): using color object for coloring the example icon

docs(icon): using table to display props instead of unordered list

docs: all instances of 'css' are now in uppercase

docs: code/format cleanup

chore: prettier

feat: Added Utils directory for docs, FormatTypes component

This takes an array of 'types' from the api sections and formats it much more cleanly and legibly

docs(typography): uses the FormatTypes component

feat(FormatTypes): added noInterpret functionality

When noInterpret is passed, uses dangerouslySetHtml to output exactly what is in the types array

docs: All components now use FormatTypes in their api tables

docs(FormatTypes): minor typo fixes

docs: all color/background now have full types listed

string | rgb | rgba

docs: added bottom padding to content area

docs: set percentage widths on api table columns

feat(ColorBlurb): new component for documentation

color/background are common props, this allows regurgitation of the same info with some variation configurable via props

docs: updated docs to use ColorBlurb where appropriate

docs: tried to be more explicit with what units are allowed

fix(docs): Added lang attribute to html tag

docs(icon): added enumerated values for scale

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Changes based on feedback from alpha testers. Some quality of life improvements (for the developer) with the addition of the `ColorBlurb` and `FormatType` utility components as noted in the commit messages above.
