### PR TITLE
feat(avatar): adding avatar src

### DIFF
--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -18,12 +18,16 @@ The `Avatar` component renders a generic avatar graphic, or a stylized label.
 
     <div>
         <Typography tag="h3">Avatar with an image...</Typography>
-        <Avatar src="https://avatars3.githubusercontent.com/u/24923730?s=460&v=4" />
+        <Avatar alt="User Avatar" src="https://avatars3.githubusercontent.com/u/24923730?s=460&v=4" />
     </div>
 </section>
 ```
 
 <br />
+
+The props `src` and `label` are not intended to be used simultaneously. 
+
+<br  />
 
 ---
 
@@ -52,6 +56,12 @@ The `Avatar` component renders a generic avatar graphic, or a stylized label.
         <tr>
             <td>src</td>
             <td>Replace the default avatar graphic with an image.</td>
+            <td>string</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td>alt</td>
+            <td>Replace the default avatar alt tag when a `src` is provided.</td>
             <td>string</td>
             <td>-</td>
         </tr>

--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -61,7 +61,7 @@ The props `src` and `label` are not intended to be used simultaneously.
         </tr>
         <tr>
             <td>alt</td>
-            <td>Replace the default avatar alt tag when a `src` is provided.</td>
+            <td>Replace the default avatar alt tag when a <pre>src</pre> is provided.</td>
             <td>string</td>
             <td>-</td>
         </tr>

--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -5,17 +5,22 @@ The `Avatar` component renders a generic avatar graphic, or a stylized label.
 <br />
 
 ```tsx live
-    <section>
-        <div>
-            <Typography tag="h3">Avatar with a label...</Typography>
-            <Avatar label="ps" />
-        </div>
+<section>
+    <div>
+        <Typography tag="h3">Avatar with a label...</Typography>
+        <Avatar label="ps" />
+    </div>
 
-        <div>
-            <Typography tag="h3">Avatar without a label...</Typography>
-            <Avatar />
-        </div>
-    </section>
+    <div>
+        <Typography tag="h3">Avatar without a label...</Typography>
+        <Avatar />
+    </div>
+
+    <div>
+        <Typography tag="h3">Avatar with an image...</Typography>
+        <Avatar src="https://avatars3.githubusercontent.com/u/24923730?s=460&v=4" />
+    </div>
+</section>
 ```
 
 <br />
@@ -36,12 +41,19 @@ The `Avatar` component renders a generic avatar graphic, or a stylized label.
     <tbody>
         <tr>
             <td>label</td>
-            <td>Replace the default avatar graphic with the first two characters of the provided
-                string.  Letters will be automatically capitalized.
+            <td>
+                Replace the default avatar graphic with the first two characters
+                of the provided string. Letters will be automatically
+                capitalized.
             </td>
+            <td>string</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td>src</td>
+            <td>Replace the default avatar graphic with an image.</td>
             <td>string</td>
             <td>-</td>
         </tr>
     </tbody>
 </table>
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "0.0.1-beta.14",
+  "version": "0.0.1-beta.15",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Avatar/Avatar.component.spec.tsx
+++ b/src/Avatar/Avatar.component.spec.tsx
@@ -31,8 +31,8 @@ describe('Component: Avatar', () => {
     it('should render the first two characters of any label passed in', () => {
         const testLabel = 'TT';
         const subjectWithInitials = mount(<Avatar label={testLabel} />);
-        expect(subjectWithInitials.find('div.avatar-container').text()).toBe(
-            testLabel
-        );
+        expect(
+            subjectWithInitials.find('div.anchor-avatar-container').text()
+        ).toBe(testLabel);
     });
 });

--- a/src/Avatar/Avatar.component.tsx
+++ b/src/Avatar/Avatar.component.tsx
@@ -10,7 +10,7 @@ interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
     className?: string;
     // Configuration
     label?: string;
-    src?: string | React.ReactElement<any> | React.FunctionComponent;
+    src?: string;
 }
 
 /* tslint:disable max-line-length */
@@ -59,6 +59,11 @@ const InnerBorder = styled('div')`
     align-items: center;
     border-radius: circular;
     overflow: hidden;
+
+    img {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
 `;
 
 export const Avatar = ({
@@ -70,7 +75,9 @@ export const Avatar = ({
     <StyledAvatar className={classNames('anchor-avatar', className)} {...props}>
         <InnerBorder className="avatar-container">
             {/* TODO: handle image src */}
-            {label ? label.substr(0, 2).toUpperCase() : <DefaultAvatar />}
+            {label && label.substr(0, 2).toUpperCase()}
+            {src && <img src={src} alt="Anchor Avatar" />}
+            {!label && !src && <DefaultAvatar />}
         </InnerBorder>
     </StyledAvatar>
 );

--- a/src/Avatar/Avatar.component.tsx
+++ b/src/Avatar/Avatar.component.tsx
@@ -11,6 +11,7 @@ interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
     // Configuration
     label?: string;
     src?: string;
+    alt?: string;
 }
 
 /* tslint:disable max-line-length */
@@ -70,13 +71,13 @@ export const Avatar = ({
     className,
     src,
     label,
+    alt,
     ...props
 }: AvatarProps): React.ReactElement<AvatarProps> => (
     <StyledAvatar className={classNames('anchor-avatar', className)} {...props}>
-        <InnerBorder className="avatar-container">
-            {/* TODO: handle image src */}
+        <InnerBorder className="anchor-avatar-container">
             {label && label.substr(0, 2).toUpperCase()}
-            {src && <img src={src} alt="Anchor Avatar" />}
+            {src && <img src={src} alt={alt ? alt : 'Anchor Avatar'} />}
             {!label && !src && <DefaultAvatar />}
         </InnerBorder>
     </StyledAvatar>

--- a/src/Avatar/Avatar.stories.tsx
+++ b/src/Avatar/Avatar.stories.tsx
@@ -33,7 +33,12 @@ storiesOf('Components/Avatar', module)
                 <Typography tag="h1">Avatar With Initials</Typography>
                 <Avatar label={text('Avatar Initials', 'CC')} />
                 <Typography tag="h1">Avatar With Picture</Typography>
-                <Avatar src="https://avatars3.githubusercontent.com/u/24923730?s=460&v=4" />
+                <Avatar
+                    src={text(
+                        'Avatar Url',
+                        'https://avatars3.githubusercontent.com/u/24923730?s=460&v=4'
+                    )}
+                />
             </StyledStory>
         </ThemeProvider>
     ));

--- a/src/Avatar/Avatar.stories.tsx
+++ b/src/Avatar/Avatar.stories.tsx
@@ -7,6 +7,7 @@ import { text } from '@storybook/addon-knobs';
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 // COMPONENTS
 import { Avatar } from './Avatar.component';
+import { Typography } from '../Typography';
 // README
 import * as README from './README.md';
 // THEME
@@ -27,10 +28,12 @@ storiesOf('Components/Avatar', module)
     .add('Default', () => (
         <ThemeProvider theme={RootTheme}>
             <StyledStory>
-                <p>Avatar</p>
+                <Typography tag="h1">Avatar</Typography>
                 <Avatar />
-                <p>Avatar With Initials</p>
+                <Typography tag="h1">Avatar With Initials</Typography>
                 <Avatar label={text('Avatar Initials', 'CC')} />
+                <Typography tag="h1">Avatar With Picture</Typography>
+                <Avatar src="https://avatars3.githubusercontent.com/u/24923730?s=460&v=4" />
             </StyledStory>
         </ThemeProvider>
     ));

--- a/src/Avatar/__snapshots__/Avatar.component.spec.tsx.snap
+++ b/src/Avatar/__snapshots__/Avatar.component.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`Component: Avatar should match its snapshot. 1`] = `
   className="anchor-avatar c0"
 >
   <div
-    className="avatar-container c1"
+    className="anchor-avatar-container c1"
   >
     <svg
       height="36"

--- a/src/Avatar/__snapshots__/Avatar.component.spec.tsx.snap
+++ b/src/Avatar/__snapshots__/Avatar.component.spec.tsx.snap
@@ -53,6 +53,13 @@ exports[`Component: Avatar should match its snapshot. 1`] = `
   overflow: hidden;
 }
 
+.c1 img {
+  -webkit-flex: 0 0 100%;
+  -ms-flex: 0 0 100%;
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
 <div
   className="anchor-avatar c0"
 >


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config

---------
**Outline your feature or bug-fix below**

My code adds the ability for users to render an image in the Avatar component via the `src` prop.
