### PR TITLE
fix(ThemeProvider): Correctly exports the ThemeProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "0.0.1-beta.16",
+  "version": "0.0.1-beta.17",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,6 +1,7 @@
 // Theme Files
 import { typography } from './typography.theme';
 import { ColorsTheme, colors } from './colors.theme';
+import { ThemeProvider as XstyledThemeProvider } from '@xstyled/styled-components';
 
 // TODO: ============================================================ move all of these v consts to a different location
 
@@ -38,4 +39,5 @@ export const RootTheme = {
     },
 };
 
-export { ThemeProvider } from '@xstyled/styled-components';
+// Exporting out @xstyled's ThemeProvider. Only way I could get it to work w/o issues.
+export class ThemeProvider extends XstyledThemeProvider {}


### PR DESCRIPTION
Had to import the ThemeProvider into theme and extend its class, similar to ModalProvider

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
