### PR TITLE
feat(dropdown) abstract positioning variants, add trigger for both click and hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "0.0.1-beta.17",
+  "version": "0.0.1-beta.18",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
+++ b/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
@@ -10,20 +10,20 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
   border-radius: 4px;
   padding: 0.5rem 1rem;
   cursor: pointer;
-  -webkit-transition: background-color 500ms;
-  transition: background-color 500ms;
-  background-color: #FFFFFF;
+  -webkit-transition: background 500ms;
+  transition: background 500ms;
+  background: white;
   -webkit-text-decoration: none;
   text-decoration: none;
   height: 2.75rem;
 }
 
 .c1:hover {
-  background-color: #FAFAFA;
+  background: #FAFAFA;
 }
 
 .c1.active {
-  background-color: #F1F1F1;
+  background: #F1F1F1;
 }
 
 .c2 {
@@ -191,20 +191,20 @@ exports[`Component: ResultsContainer should be defined 1`] = `
   border-radius: 4px;
   padding: 0.5rem 1rem;
   cursor: pointer;
-  -webkit-transition: background-color 500ms;
-  transition: background-color 500ms;
-  background-color: #FFFFFF;
+  -webkit-transition: background 500ms;
+  transition: background 500ms;
+  background: white;
   -webkit-text-decoration: none;
   text-decoration: none;
   height: 2.75rem;
 }
 
 .c2:hover {
-  background-color: #FAFAFA;
+  background: #FAFAFA;
 }
 
 .c2.active {
-  background-color: #F1F1F1;
+  background: #F1F1F1;
 }
 
 .c3 {

--- a/src/DropDown/Arrow/Arrow.component.spec.tsx
+++ b/src/DropDown/Arrow/Arrow.component.spec.tsx
@@ -2,20 +2,17 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 // COMPONENT
-import { renderArrow } from './Arrow.component';
+import { Arrow } from './Arrow.component';
 // ENZYME
 import { shallow, mount } from 'enzyme';
 
 // TEST SETUP
 const subject = (
     <div>
-        {renderArrow('top', true)}
-        <br />
-        {renderArrow('bottom', true)}
-        <br />
-        {renderArrow('left', true)}
-        <br />
-        {renderArrow('right', true)}
+        <Arrow position="top" />
+        <Arrow position="bottom" />
+        <Arrow position="left" />
+        <Arrow position="right" />
     </div>
 );
 const wrapper = mount(subject);

--- a/src/DropDown/Arrow/Arrow.component.tsx
+++ b/src/DropDown/Arrow/Arrow.component.tsx
@@ -1,75 +1,97 @@
-// REACT
-import * as React from 'react';
 // VENDOR
 import styled, { css } from '@xstyled/styled-components';
+import { th } from '@xstyled/system';
 // COMPONENTS
 import { Position } from '../DropDown.component';
 
-const ArrowBase = css`
+export const DefaultSize = '0.625rem';
+
+export interface ArrowProps {
+    position: Position;
+    indent?: string;
+    size?: string;
+    border?: string;
+    shadow?: string;
+    background?: string;
+}
+
+export const Arrow = styled('div')<ArrowProps>`
     position: absolute;
-    width: 0;
-    height: 0;
-`;
+    box-sizing: border-box;
+    ${({ background, shadow, border, size = DefaultSize }) =>
+        css({
+            width: size,
+            height: size,
+            border,
+            background: th.color(background),
+            boxShadow: shadow,
+        })}
+    z-index: -1;
+    transform: rotate(45deg);
 
-// TODO: add shadow rotate(45deg)
-const CaretHeight = '0.4rem';
-const CaretIndent = '0.75rem';
-const CaretSize = '0.5rem';
-
-export const ArrowUp = styled('div')`
-    ${ArrowBase};
-    top: -${CaretHeight};
-    left: ${CaretIndent};
-    border-left: ${CaretSize} solid transparent;
-    border-right: ${CaretSize} solid transparent;
-    border-bottom: ${CaretSize} solid white;
-`;
-
-export const ArrowDown = styled('div')`
-    ${ArrowBase};
-    bottom: -${CaretHeight};
-    left: ${CaretIndent};
-    border-left: ${CaretSize} solid transparent;
-    border-right: ${CaretSize} solid transparent;
-    border-top: ${CaretSize} solid white;
-`;
-export const ArrowRight = styled('div')`
-    ${ArrowBase};
-    top: ${CaretIndent};
-    right: -${CaretHeight};
-    border-top: ${CaretSize} solid transparent;
-    border-bottom: ${CaretSize} solid transparent;
-    border-left: ${CaretSize} solid white;
-`;
-
-export const ArrowLeft = styled('div')`
-    ${ArrowBase};
-    top: ${CaretIndent};
-    left: -${CaretHeight};
-    border-top: ${CaretSize} solid transparent;
-    border-bottom: ${CaretSize} solid transparent;
-    border-right: ${CaretSize} solid white;
-`;
-
-export const renderArrow = (position: Position, isShown?: boolean) => {
-    let arrowElement;
-    if (isShown) {
+    ${({ position, indent, size = DefaultSize }) => {
         switch (position) {
             case 'bottom':
-                arrowElement = <ArrowUp />;
-                break;
+                return css({
+                    top: `calc(-${size} / 2)`,
+                    left: `calc(50% - ${size} / 2)`,
+                });
+            case 'bottomEnd':
+                return css({
+                    top: `calc(-${size} / 2)`,
+                    right: indent,
+                });
+            case 'bottomStart':
+                return css({
+                    top: `calc(-${size} / 2)`,
+                    left: indent,
+                });
             case 'top':
-                arrowElement = <ArrowDown />;
-                break;
+                return css({
+                    bottom: `calc(-${size} / 2)`,
+                    right: `calc(50% - ${size} / 2)`,
+                });
+            case 'topEnd':
+                return css({
+                    bottom: `calc(-${size} / 2)`,
+                    right: indent,
+                });
+            case 'topStart':
+                return css({
+                    bottom: `calc(-${size} / 2)`,
+                    left: indent,
+                });
             case 'right':
-                arrowElement = <ArrowLeft />;
-                break;
+                return css({
+                    top: `calc(50% - ${size} / 2)`,
+                    left: `calc(-${size} / 2)`,
+                });
+            case 'rightEnd':
+                return css({
+                    bottom: indent,
+                    left: `calc(-${size} / 2)`,
+                });
+            case 'rightStart':
+                return css({
+                    top: indent,
+                    left: `calc(-${size} / 2)`,
+                });
             case 'left':
-                arrowElement = <ArrowRight />;
-                break;
-            default:
-                break;
+                return css({
+                    top: `calc(50% - ${size} / 2)`,
+                    right: `calc(-${size} / 2)`,
+                });
+            case 'leftEnd':
+                return css({
+                    bottom: indent,
+                    right: `calc(-${size} / 2)`,
+                });
+            case 'leftStart':
+                return css({
+                    top: indent,
+                    right: `calc(-${size} / 2)`,
+                });
         }
-    }
-    return arrowElement;
-};
+        return null;
+    }}
+`;

--- a/src/DropDown/Arrow/__snapshots__/Arrow.component.spec.tsx.snap
+++ b/src/DropDown/Arrow/__snapshots__/Arrow.component.spec.tsx.snap
@@ -1,63 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component: DropDown Component: Arrow should render in the DOM 1`] = `
-.c1 {
-  position: absolute;
-  width: 0;
-  height: 0;
-  top: -0.4rem;
-  left: 0.75rem;
-  border-left: 0.5rem solid transparent;
-  border-right: 0.5rem solid transparent;
-  border-bottom: 0.5rem solid white;
-}
-
 .c0 {
   position: absolute;
-  width: 0;
-  height: 0;
-  bottom: -0.4rem;
-  left: 0.75rem;
-  border-left: 0.5rem solid transparent;
-  border-right: 0.5rem solid transparent;
-  border-top: 0.5rem solid white;
+  box-sizing: border-box;
+  width: 0.625rem;
+  height: 0.625rem;
+  z-index: -1;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  bottom: calc(-0.625rem / 2);
+  right: calc(50% - 0.625rem / 2);
+}
+
+.c1 {
+  position: absolute;
+  box-sizing: border-box;
+  width: 0.625rem;
+  height: 0.625rem;
+  z-index: -1;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  top: calc(-0.625rem / 2);
+  left: calc(50% - 0.625rem / 2);
 }
 
 .c2 {
   position: absolute;
-  width: 0;
-  height: 0;
-  top: 0.75rem;
-  right: -0.4rem;
-  border-top: 0.5rem solid transparent;
-  border-bottom: 0.5rem solid transparent;
-  border-left: 0.5rem solid white;
+  box-sizing: border-box;
+  width: 0.625rem;
+  height: 0.625rem;
+  z-index: -1;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  top: calc(50% - 0.625rem / 2);
+  right: calc(-0.625rem / 2);
 }
 
 .c3 {
   position: absolute;
-  width: 0;
-  height: 0;
-  top: 0.75rem;
-  left: -0.4rem;
-  border-top: 0.5rem solid transparent;
-  border-bottom: 0.5rem solid transparent;
-  border-right: 0.5rem solid white;
+  box-sizing: border-box;
+  width: 0.625rem;
+  height: 0.625rem;
+  z-index: -1;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  top: calc(50% - 0.625rem / 2);
+  left: calc(-0.625rem / 2);
 }
 
 <div>
   <div
     className="c0"
   />
-  <br />
   <div
     className="c1"
   />
-  <br />
   <div
     className="c2"
   />
-  <br />
   <div
     className="c3"
   />

--- a/src/DropDown/DropDown.component.spec.tsx
+++ b/src/DropDown/DropDown.component.spec.tsx
@@ -20,12 +20,16 @@ describe('Component: DropDown', () => {
     test('should toggle when clicked', () => {
         const wrapper = mount(subject);
         wrapper.find('div.anchor-drop-down').simulate('click');
-        expect(
-            wrapper.find('div.anchor-down-down-container').props().hidden
-        ).toBeFalsy();
+
+        // I'm creating a variable here to cast to any and avoid
+        // a "toHaveStyleRule" type def error.
+        // todo: include the type def
+        let expectation: any = expect(wrapper.find('div.anchor-drop-down-container'));
+        expectation.toHaveStyleRule('visibility', 'visible');
+
         wrapper.find('div.anchor-drop-down').simulate('click');
-        expect(
-            wrapper.find('div.anchor-down-down-container').props().hidden
-        ).toBeTruthy();
+
+        expectation = expect(wrapper.find('div.anchor-drop-down-container'));
+        expectation.toHaveStyleRule('visibility', 'hidden');
     });
 });

--- a/src/DropDown/DropDown.component.spec.tsx
+++ b/src/DropDown/DropDown.component.spec.tsx
@@ -24,7 +24,9 @@ describe('Component: DropDown', () => {
         // I'm creating a variable here to cast to any and avoid
         // a "toHaveStyleRule" type def error.
         // todo: include the type def
-        let expectation: any = expect(wrapper.find('div.anchor-drop-down-container'));
+        let expectation: any = expect(
+            wrapper.find('div.anchor-drop-down-container')
+        );
         expectation.toHaveStyleRule('visibility', 'visible');
 
         wrapper.find('div.anchor-drop-down').simulate('click');

--- a/src/DropDown/DropDown.component.spec.tsx
+++ b/src/DropDown/DropDown.component.spec.tsx
@@ -19,7 +19,7 @@ describe('Component: DropDown', () => {
     });
     test('should toggle when clicked', () => {
         const wrapper = mount(subject);
-        wrapper.find('div.anchor-drop-down').simulate('click');
+        wrapper.setState({ clicked: true });
 
         // I'm creating a variable here to cast to any and avoid
         // a "toHaveStyleRule" type def error.
@@ -29,7 +29,9 @@ describe('Component: DropDown', () => {
         );
         expectation.toHaveStyleRule('visibility', 'visible');
 
-        wrapper.find('div.anchor-drop-down').simulate('click');
+        // enzyme's simulate('click') calls the onClick prop directly
+        // which we're no longer using
+        wrapper.setState({ clicked: false });
 
         expectation = expect(wrapper.find('div.anchor-drop-down-container'));
         expectation.toHaveStyleRule('visibility', 'hidden');

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -23,6 +23,7 @@ interface DropDownProps extends React.HTMLAttributes<HTMLDivElement> {
     shadow?: string;
     showArrow?: boolean;
     border?: string;
+    borderRadius?: string;
     background?: string;
     spacing?: number;
     arrowIndent?: string;
@@ -104,6 +105,7 @@ interface DropDownContainerProps extends React.HTMLAttributes<HTMLDivElement> {
     shadow?: string;
     border?: string;
     background?: string;
+    borderRadius?: string;
     active?: boolean;
     children?: any;
     className?: string;
@@ -117,13 +119,13 @@ const StyledDropDownContainer = styled('div')<DropDownContainerProps>`
     z-index: 1;
     min-width: 10rem;
 
-    ${({ border, shadow, active }) =>
+    ${({ border, borderRadius, shadow, active }) =>
         css({
             border,
+            borderRadius,
             boxShadow: shadow,
             visibility: active ? 'visible' : 'hidden',
         })};
-    border-radius: base;
 
     ${({ position, height, width, containerHeight, containerWidth }) =>
         positionVariants(
@@ -273,6 +275,7 @@ export class DropDown extends React.Component<DropDownProps> {
             position = 'bottom',
             shadow = '0 0 0.5rem 0 rgba(0,0,0,0.2)',
             border = 'light',
+            borderRadius = 'base',
             background = 'white',
             trigger,
             ...props
@@ -315,6 +318,7 @@ export class DropDown extends React.Component<DropDownProps> {
                     ref={this.containerReference}
                     shadow={shadow}
                     border={border}
+                    borderRadius={borderRadius}
                     position={position}
                     active={showDropdown}
                     height={height}

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -25,7 +25,8 @@ interface DropDownProps extends React.HTMLAttributes<HTMLDivElement> {
     border?: string;
     background?: string;
     spacing?: number;
-    indent?: string;
+    arrowIndent?: string;
+    arrowSize?: string;
 }
 
 interface DropDownState {
@@ -214,14 +215,12 @@ export class DropDown extends React.Component<DropDownProps> {
         const unclick$ = merge(domClick$, escapeKey$);
 
         this.unclicked$ = unclick$.subscribe(clicked => {
-            console.log('unclicked$', clicked);
             this.setState({ clicked });
         });
 
         this.hovered$ = merge(mouseEnter$, mouseLeave$, unclick$)
             .pipe(distinctUntilChanged())
             .subscribe(hovered => {
-                console.log('hovered$', hovered);
                 this.setState({ hovered });
             });
     }
@@ -268,7 +267,8 @@ export class DropDown extends React.Component<DropDownProps> {
             className,
             overlay,
             spacing,
-            indent = '0.75rem',
+            arrowIndent = '0.75rem',
+            arrowSize,
             showArrow = true,
             position = 'bottom',
             shadow = '0 0 0.5rem 0 rgba(0,0,0,0.2)',
@@ -326,7 +326,8 @@ export class DropDown extends React.Component<DropDownProps> {
                     {showArrow && (
                         <Arrow
                             position={position}
-                            indent={indent}
+                            size={arrowSize}
+                            indent={arrowIndent}
                             background={background}
                             shadow={shadow}
                             border={border}

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -10,11 +10,13 @@ import { filter, map, mapTo, distinctUntilChanged } from 'rxjs/operators';
 import { get } from '../utils/get/get';
 import { Arrow } from './Arrow/Arrow.component';
 import { positionVariants, Position } from '../utils/position/position';
+
 export { Position } from '../utils/position/position';
+export type Trigger = 'hover' | 'click' | 'both';
 
 interface DropDownProps extends React.HTMLAttributes<HTMLDivElement> {
     overlay?: React.ReactElement<any> | Array<React.ReactElement<any>>;
-    trigger?: 'hover' | 'click' | 'both';
+    trigger?: Trigger;
     className?: string;
     children?: any;
     // Configuration

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -32,6 +32,7 @@ const MockList = () => (
     <List>
         {listItemArray.map(({ key, label }: any) => (
             <ListItem
+                background='transparent'
                 key={key}
                 onClick={() => {
                     /* tslint:disable no-console */
@@ -163,7 +164,8 @@ storiesOf('Components/DropDown', module)
                                             text('background', '') || undefined
                                         }
                                         border={text('border', '') || undefined}
-                                        indent={text('indent', '') || undefined}
+                                        arrowIndent={text('arrowIndent', '') || undefined}
+                                        arrowSize={text('arrowSize', '') || undefined}
                                         spacing={
                                             spacing
                                                 ? parseInt(spacing)

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -6,15 +6,15 @@ import { storiesOf } from '@storybook/react';
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 import { text, select, boolean } from '@storybook/addon-knobs';
 // COMPONENTS
-import { DropDown, Position } from './DropDown.component';
+import { DropDown, Position, Trigger } from './DropDown.component';
 import { Button } from '../Button';
 import { List, Item as ListItem } from '../List';
 import { Typography } from '../Typography';
 import { Container, Row, Col } from '../Grid';
+// THEME
+import { RootTheme } from '../theme';
 // README
 import * as README from './README.md';
-import { RootTheme } from '../theme';
-// THEME
 
 const StyledStory = styled('div')`
     padding: 2rem 5rem;
@@ -130,7 +130,7 @@ storiesOf('Components/DropDown', module)
                                 <DropDown
                                     overlay={<MockList />}
                                     position={select<Position>(
-                                        'Dropdown Position',
+                                        'position',
                                         [
                                             'topStart',
                                             'top',
@@ -147,8 +147,8 @@ storiesOf('Components/DropDown', module)
                                         ],
                                         'bottom'
                                     )}
-                                    trigger={select<'click' | 'hover' | 'both'>(
-                                        'Dropdown Trigger',
+                                    trigger={select<Trigger>(
+                                        'trigger',
                                         ['click', 'hover', 'both'],
                                         'hover'
                                     )}
@@ -170,7 +170,8 @@ storiesOf('Components/DropDown', module)
                                     spacing={text('spacing', '') || undefined}
                                 >
                                     <Button>
-                                        {text('Dropdown Text', 'Dropdown')}
+                                        {/* Not a prop, just for testing various widths */}
+                                        {text('Text', 'Dropdown')}
                                     </Button>
                                 </DropDown>
                             </div>

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -119,76 +119,64 @@ storiesOf('Components/DropDown', module)
             </StyledStory>
         </ThemeProvider>
     ))
-
-    .add('Knobs Demo', () => {
-        // Using "text" so that we can distinguish between
-        // `undefined` spacing and `0` (for default behavior)
-        const spacing = text('spacing', '');
-
-        return (
-            <ThemeProvider theme={RootTheme}>
-                <StyledStory>
-                    <Container>
-                        <Row>
-                            <Col offset={{ xs: 3, sm: 3, md: 3, lg: 3 }} lg={4}>
-                                <div>
-                                    <Typography tag="h1">DropDown</Typography>
-                                    <DropDown
-                                        overlay={<MockList />}
-                                        position={select<Position>(
-                                            'Dropdown Position',
-                                            [
-                                                'topStart',
-                                                'top',
-                                                'topEnd',
-                                                'rightStart',
-                                                'right',
-                                                'rightEnd',
-                                                'bottomEnd',
-                                                'bottom',
-                                                'bottomStart',
-                                                'leftEnd',
-                                                'left',
-                                                'leftStart',
-                                            ],
-                                            'bottom'
-                                        )}
-                                        trigger={select<'click' | 'hover'>(
-                                            'Dropdown Trigger',
-                                            ['click', 'hover'],
-                                            'hover'
-                                        )}
-                                        showArrow={boolean('showArrow', true)}
-                                        shadow={text('shadow', '') || undefined}
-                                        background={
-                                            text('background', '') || undefined
-                                        }
-                                        border={text('border', '') || undefined}
-                                        borderRadius={
-                                            text('borderRadius', '') ||
-                                            undefined
-                                        }
-                                        arrowIndent={
-                                            text('arrowIndent', '') || undefined
-                                        }
-                                        arrowSize={
-                                            text('arrowSize', '') || undefined
-                                        }
-                                        spacing={
-                                            spacing
-                                                ? parseInt(spacing, 10)
-                                                : undefined
-                                        }
-                                    >
-                                        <Button>
-                                            {text('Dropdown Text', 'Dropdown')}
-                                        </Button>
-                                    </DropDown>
-                                </div>
-                            </Col>
-                        </Row>
-                    </Container>
-                </StyledStory>
-            </ThemeProvider>
-        );
-    });
+    .add('Knobs Demo', () => (
+        <ThemeProvider theme={RootTheme}>
+            <StyledStory>
+                <Container>
+                    <Row>
+                        <Col offset={{ xs: 3, sm: 3, md: 3, lg: 3 }} lg={4}>
+                            <div>
+                                <Typography tag="h1">DropDown</Typography>
+                                <DropDown
+                                    overlay={<MockList />}
+                                    position={select<Position>(
+                                        'Dropdown Position',
+                                        [
+                                            'topStart',
+                                            'top',
+                                            'topEnd',
+                                            'rightStart',
+                                            'right',
+                                            'rightEnd',
+                                            'bottomEnd',
+                                            'bottom',
+                                            'bottomStart',
+                                            'leftEnd',
+                                            'left',
+                                            'leftStart',
+                                        ],
+                                        'bottom'
+                                    )}
+                                    trigger={select<'click' | 'hover' | 'both'>(
+                                        'Dropdown Trigger',
+                                        ['click', 'hover', 'both'],
+                                        'hover'
+                                    )}
+                                    showArrow={boolean('showArrow', true)}
+                                    shadow={text('shadow', '') || undefined}
+                                    background={
+                                        text('background', '') || undefined
+                                    }
+                                    border={text('border', '') || undefined}
+                                    borderRadius={
+                                        text('borderRadius', '') || undefined
+                                    }
+                                    arrowIndent={
+                                        text('arrowIndent', '') || undefined
+                                    }
+                                    arrowSize={
+                                        text('arrowSize', '') || undefined
+                                    }
+                                    spacing={text('spacing', '') || undefined}
+                                >
+                                    <Button>
+                                        {text('Dropdown Text', 'Dropdown')}
+                                    </Button>
+                                </DropDown>
+                            </div>
+                        </Col>
+                    </Row>
+                </Container>
+            </StyledStory>
+        </ThemeProvider>
+    ));

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -6,7 +6,7 @@ import { storiesOf } from '@storybook/react';
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 import { text, select, boolean } from '@storybook/addon-knobs';
 // COMPONENTS
-import { DropDown } from './DropDown.component';
+import { DropDown, Position } from './DropDown.component';
 import { Button } from '../Button';
 import { List, Item as ListItem } from '../List';
 import { Typography } from '../Typography';
@@ -118,38 +118,67 @@ storiesOf('Components/DropDown', module)
             </StyledStory>
         </ThemeProvider>
     ))
-    .add('Knobs Demo', () => (
-        <ThemeProvider theme={RootTheme}>
-            <StyledStory>
-                <Container>
-                    <Row>
-                        <Col offset={{ xs: 3, sm: 3, md: 3, lg: 3 }} lg={4}>
-                            <div>
-                                <Typography tag="h1">DropDown</Typography>
-                                <DropDown
-                                    overlay={<MockList />}
-                                    position={select<
-                                        'top' | 'bottom' | 'right' | 'left'
-                                    >(
-                                        'Dropdown Position',
-                                        ['top', 'bottom', 'right', 'left'],
-                                        'bottom'
-                                    )}
-                                    trigger={select<'click' | 'hover'>(
-                                        'Dropdown Trigger',
-                                        ['click', 'hover'],
-                                        'hover'
-                                    )}
-                                    showArrow={boolean('showArrow', false)}
-                                    shadow={text('shadow', '') || undefined}
-                                    background={text('background', '') || undefined}
-                                >
-                                    <Button>{text('Dropdown Text', 'Dropdown')}</Button>
-                                </DropDown>
-                            </div>
-                        </Col>
-                    </Row>
-                </Container>
-            </StyledStory>
-        </ThemeProvider>
-    ));
+
+    .add('Knobs Demo', () => {
+        // Using "text" so that we can distinguish between
+        // `undefined` spacing and `0` (for default behavior)
+        const spacing = text('spacing', '');
+
+        return (
+            <ThemeProvider theme={RootTheme}>
+                <StyledStory>
+                    <Container>
+                        <Row>
+                            <Col offset={{ xs: 3, sm: 3, md: 3, lg: 3 }} lg={4}>
+                                <div>
+                                    <Typography tag="h1">DropDown</Typography>
+                                    <DropDown
+                                        overlay={<MockList />}
+                                        position={select<Position>(
+                                            'Dropdown Position',
+                                            [
+                                                'topStart',
+                                                'top',
+                                                'topEnd',
+                                                'rightStart',
+                                                'right',
+                                                'rightEnd',
+                                                'bottomEnd',
+                                                'bottom',
+                                                'bottomStart',
+                                                'leftEnd',
+                                                'left',
+                                                'leftStart',
+                                            ],
+                                            'bottom'
+                                        )}
+                                        trigger={select<'click' | 'hover'>(
+                                            'Dropdown Trigger',
+                                            ['click', 'hover'],
+                                            'hover'
+                                        )}
+                                        showArrow={boolean('showArrow', true)}
+                                        shadow={text('shadow', '') || undefined}
+                                        background={
+                                            text('background', '') || undefined
+                                        }
+                                        border={text('border', '') || undefined}
+                                        indent={text('indent', '') || undefined}
+                                        spacing={
+                                            spacing
+                                                ? parseInt(spacing)
+                                                : undefined
+                                        }
+                                    >
+                                        <Button>
+                                            {text('Dropdown Text', 'Dropdown')}
+                                        </Button>
+                                    </DropDown>
+                                </div>
+                            </Col>
+                        </Row>
+                    </Container>
+                </StyledStory>
+            </ThemeProvider>
+        );
+    });

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -32,7 +32,7 @@ const MockList = () => (
     <List>
         {listItemArray.map(({ key, label }: any) => (
             <ListItem
-                background='transparent'
+                background="transparent"
                 key={key}
                 onClick={() => {
                     /* tslint:disable no-console */
@@ -164,11 +164,19 @@ storiesOf('Components/DropDown', module)
                                             text('background', '') || undefined
                                         }
                                         border={text('border', '') || undefined}
-                                        arrowIndent={text('arrowIndent', '') || undefined}
-                                        arrowSize={text('arrowSize', '') || undefined}
+                                        borderRadius={
+                                            text('borderRadius', '') ||
+                                            undefined
+                                        }
+                                        arrowIndent={
+                                            text('arrowIndent', '') || undefined
+                                        }
+                                        arrowSize={
+                                            text('arrowSize', '') || undefined
+                                        }
                                         spacing={
                                             spacing
-                                                ? parseInt(spacing)
+                                                ? parseInt(spacing, 10)
                                                 : undefined
                                         }
                                     >

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -4,9 +4,10 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
-import { text, select } from '@storybook/addon-knobs';
+import { text, select, boolean } from '@storybook/addon-knobs';
 // COMPONENTS
 import { DropDown } from './DropDown.component';
+import { Button } from '../Button';
 import { List, Item as ListItem } from '../List';
 import { Typography } from '../Typography';
 import { Container, Row, Col } from '../Grid';
@@ -132,15 +133,18 @@ storiesOf('Components/DropDown', module)
                                     >(
                                         'Dropdown Position',
                                         ['top', 'bottom', 'right', 'left'],
-                                        'top'
+                                        'bottom'
                                     )}
                                     trigger={select<'click' | 'hover'>(
                                         'Dropdown Trigger',
                                         ['click', 'hover'],
                                         'hover'
                                     )}
+                                    showArrow={boolean('showArrow', false)}
+                                    shadow={text('shadow', '') || undefined}
+                                    background={text('background', '') || undefined}
                                 >
-                                    <a>{text('Dropdown Label', 'Dropdown')}</a>
+                                    <Button>{text('Dropdown Text', 'Dropdown')}</Button>
                                 </DropDown>
                             </div>
                         </Col>

--- a/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
+++ b/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
@@ -1,15 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component: DropDown should render in the DOM 1`] = `
-.c2 {
+.c3 {
   position: absolute;
-  width: 0;
-  height: 0;
-  top: -0.4rem;
-  left: 0.75rem;
-  border-left: 0.5rem solid transparent;
-  border-right: 0.5rem solid transparent;
-  border-bottom: 0.5rem solid white;
+  box-sizing: border-box;
+  width: 0.625rem;
+  height: 0.625rem;
+  border: light;
+  background: white;
+  box-shadow: 0 0 0.5rem 0 rgba(0,0,0,0.2);
+  z-index: -1;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  top: calc(-0.625rem / 2);
+  left: calc(50% - 0.625rem / 2);
 }
 
 .c0 {
@@ -30,40 +35,58 @@ exports[`Component: DropDown should render in the DOM 1`] = `
   align-items: center;
   min-height: 1rem;
   min-width: 1rem;
-  padding-bottom: 0.75rem;
-  margin-bottom: -0.75rem;
+  padding-bottom: 12px;
+  margin-bottom: -12px;
 }
 
 .c1 {
-  min-width: 10rem;
   position: absolute;
-  padding: 0.25rem auto;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   z-index: 1;
-  background-color: neutrals.white.base;
-  box-shadow: 0 0 0.5rem 0 neutrals.ash.base;
+  min-width: 10rem;
+  border: light;
+  box-shadow: 0 0 0.5rem 0 rgba(0,0,0,0.2);
+  visibility: hidden;
   border-radius: base;
-  border: thin solid neutrals.silver.dark;
-  top: 0px;
   left: 0;
+  top: 0;
+  -webkit-transform: translate3d(0px,0px,0);
+  -ms-transform: translate3d(0px,0px,0);
+  transform: translate3d(0px,0px,0);
+}
+
+.c2 {
+  box-sizing: border-box;
+  border-radius: inherit;
+  width: 100%;
+  z-index: 2;
+  background: white;
 }
 
 <div
   className="anchor-drop-down c0"
   onClick={[Function]}
+  spacing={12}
 >
   <div
-    className="anchor-down-down-container c1"
-    height={0}
-    hidden={true}
-    position="bottom"
-    width={0}
+    className="anchor-drop-down-container c1"
+    height={null}
+    width={null}
   >
     <div
       className="c2"
-    />
-    <div>
-      1
+    >
+      <div>
+        1
+      </div>
     </div>
+    <div
+      className="c3"
+    />
   </div>
 </div>
 `;

--- a/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
+++ b/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
@@ -49,9 +49,9 @@ exports[`Component: DropDown should render in the DOM 1`] = `
   z-index: 1;
   min-width: 10rem;
   border: light;
+  border-radius: base;
   box-shadow: 0 0 0.5rem 0 rgba(0,0,0,0.2);
   visibility: hidden;
-  border-radius: base;
   left: 0;
   top: 0;
   -webkit-transform: translate3d(0px,0px,0);

--- a/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
+++ b/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
@@ -35,8 +35,8 @@ exports[`Component: DropDown should render in the DOM 1`] = `
   align-items: center;
   min-height: 1rem;
   min-width: 1rem;
-  padding-bottom: 12px;
-  margin-bottom: -12px;
+  padding-bottom: 0.75rem;
+  margin-bottom: -0.75rem;
 }
 
 .c1 {
@@ -69,8 +69,7 @@ exports[`Component: DropDown should render in the DOM 1`] = `
 
 <div
   className="anchor-drop-down c0"
-  onClick={[Function]}
-  spacing={12}
+  spacing="0.75rem"
 >
   <div
     className="anchor-drop-down-container c1"

--- a/src/List/Item/Item.component.tsx
+++ b/src/List/Item/Item.component.tsx
@@ -2,7 +2,8 @@
 import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
-import styled from '@xstyled/styled-components';
+import styled, { css } from '@xstyled/styled-components';
+import { th } from '@xstyled/system'
 // COMPONENTS
 import { Typography } from '../../Typography';
 
@@ -18,6 +19,7 @@ export interface ItemProps extends React.HTMLAttributes<HTMLAnchorElement> {
     prefix?: any;
     suffix?: any;
     size?: 'sm' | 'lg';
+    background?: string;
 }
 
 const StyledItem = styled('a')<ItemProps>`
@@ -26,17 +28,19 @@ const StyledItem = styled('a')<ItemProps>`
     border-radius: base;
     padding: 0.5rem 1rem;
     cursor: pointer;
-    transition: background-color 500ms;
-    background-color: neutrals.white.base;
+    transition: background 500ms;
+    ${({ background = 'white' }) => css({
+        background: th.color(background),
+    })}
     text-decoration: none;
     height: 2.75rem;
 
     &:hover {
-        background-color: neutrals.silver.light;
+        background: ${th.color('neutrals.silver.light')};
     }
 
     &.active {
-        background-color: neutrals.silver.base;
+        background: ${th.color('neutrals.silver.base')};
     }
 `;
 

--- a/src/List/Item/Item.component.tsx
+++ b/src/List/Item/Item.component.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
-import { th } from '@xstyled/system'
+import { th } from '@xstyled/system';
 // COMPONENTS
 import { Typography } from '../../Typography';
 
@@ -29,9 +29,10 @@ const StyledItem = styled('a')<ItemProps>`
     padding: 0.5rem 1rem;
     cursor: pointer;
     transition: background 500ms;
-    ${({ background = 'white' }) => css({
-        background: th.color(background),
-    })}
+    ${({ background = 'white' }) =>
+        css({
+            background: th.color(background),
+        })}
     text-decoration: none;
     height: 2.75rem;
 

--- a/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
+++ b/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
@@ -10,20 +10,20 @@ exports[`Component: Item should be defined 1`] = `
   border-radius: 4px;
   padding: 0.5rem 1rem;
   cursor: pointer;
-  -webkit-transition: background-color 500ms;
-  transition: background-color 500ms;
-  background-color: #FFFFFF;
+  -webkit-transition: background 500ms;
+  transition: background 500ms;
+  background: white;
   -webkit-text-decoration: none;
   text-decoration: none;
   height: 2.75rem;
 }
 
 .c0:hover {
-  background-color: #FAFAFA;
+  background: #FAFAFA;
 }
 
 .c0.active {
-  background-color: #F1F1F1;
+  background: #F1F1F1;
 }
 
 .c1 {

--- a/src/Tooltip/Tooltip.component.tsx
+++ b/src/Tooltip/Tooltip.component.tsx
@@ -62,9 +62,10 @@ const TooltipElement = styled('div')<TooltipElementProps>`
     transition: opacity 250ms ease-in-out;
 
     &.active {
-        ${({ delay }) => css({
-            transitionDelay: delay,
-        })}
+        ${({ delay }) =>
+            css({
+                transitionDelay: delay,
+            })}
         opacity: 1;
         visibility: visible;
     }

--- a/src/Tooltip/Tooltip.component.tsx
+++ b/src/Tooltip/Tooltip.component.tsx
@@ -16,6 +16,7 @@ interface TooltipContainerProps extends React.HTMLAttributes<HTMLDivElement> {
     color?: string;
     wrap?: boolean;
     display?: string;
+    delay?: string;
 }
 
 interface TooltipContainerState {
@@ -41,13 +42,17 @@ interface TooltipElementProps {
     background?: string;
     color?: string;
     maxWidth?: string;
+    delay?: string;
 }
 
 const TooltipElement = styled('div')<TooltipElementProps>`
     position: absolute;
     box-sizing: border-box;
     ${({ background = 'rgba(0, 0, 0, 0.8)', color = 'white' }) =>
-        css({ background, color })};
+        css({
+            background: th.color(background),
+            color,
+        })};
     border-radius: base;
     font-family: ${th('typography.fontFamily')};
     font-size: 0.8rem;
@@ -57,6 +62,9 @@ const TooltipElement = styled('div')<TooltipElementProps>`
     transition: opacity 250ms ease-in-out;
 
     &.active {
+        ${({ delay }) => css({
+            transitionDelay: delay,
+        })}
         opacity: 1;
         visibility: visible;
     }
@@ -120,6 +128,7 @@ export class Tooltip extends React.Component<
             background,
             color,
             maxWidth,
+            delay,
             ...props
         } = this.props;
         const {
@@ -143,6 +152,7 @@ export class Tooltip extends React.Component<
                     className={classNames('anchor-tooltip-element', {
                         active: !hidden,
                     })}
+                    delay={delay}
                     ref={this.tooltipRef}
                     position={position}
                     height={height}

--- a/src/Tooltip/Tooltip.component.tsx
+++ b/src/Tooltip/Tooltip.component.tsx
@@ -4,20 +4,9 @@ import * as React from 'react';
 import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
 import { th } from '@xstyled/system';
-
-export type Position =
-    | 'topStart'
-    | 'top'
-    | 'topEnd'
-    | 'rightStart'
-    | 'right'
-    | 'rightEnd'
-    | 'bottomEnd'
-    | 'bottom'
-    | 'bottomStart'
-    | 'leftEnd'
-    | 'left'
-    | 'leftStart';
+// ANCHOR
+import { positionVariants, Position } from '../utils/position/position';
+export { Position } from '../utils/position/position';
 
 interface TooltipContainerProps extends React.HTMLAttributes<HTMLDivElement> {
     content: string;
@@ -54,102 +43,6 @@ interface TooltipElementProps {
     maxWidth?: string;
 }
 
-const tooltipMargin = 8;
-
-const positionVariants = (
-    position: Position,
-    height: number,
-    width: number,
-    toolTipHeight: number,
-    toolTipWidth: number
-) => {
-    switch (position) {
-        case 'topStart':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(0, -${toolTipHeight +
-                    tooltipMargin}px, 0)`,
-            });
-        case 'top':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(${width / 2 -
-                    toolTipWidth / 2}px, -${toolTipHeight +
-                    tooltipMargin}px, 0)`,
-            });
-        case 'rightStart':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(${width + tooltipMargin}px, 0, 0)`,
-            });
-        case 'right':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(${width + tooltipMargin}px, ${height /
-                    2 -
-                    toolTipHeight / 2}px, 0)`,
-            });
-        case 'rightEnd':
-            return css({
-                left: 0,
-                bottom: 0,
-                transform: `translate3d(${width + tooltipMargin}px, 0, 0)`,
-            });
-        case 'bottomEnd':
-            return css({
-                right: 0,
-                top: 0,
-                transform: `translate3d(0, ${height + tooltipMargin}px, 0)`,
-            });
-        case 'bottom':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(${width / 2 -
-                    toolTipWidth / 2}px, ${height + tooltipMargin}px, 0)`,
-            });
-        case 'bottomStart':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(0, ${height + tooltipMargin}px, 0)`,
-            });
-        case 'leftEnd':
-            return css({
-                left: 0,
-                bottom: 0,
-                transform: `translate3d(-${toolTipWidth +
-                    tooltipMargin}px, 0, 0)`,
-            });
-        case 'left':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(-${toolTipWidth +
-                    tooltipMargin}px, ${height / 2 - toolTipHeight / 2}px, 0)`,
-            });
-        case 'leftStart':
-            return css({
-                left: 0,
-                top: 0,
-                transform: `translate3d(-${toolTipWidth +
-                    tooltipMargin}px, 0, 0)`,
-            });
-        case 'topEnd':
-        default:
-            return css({
-                right: 0,
-                top: 0,
-                transform: `translate3d(0, -${toolTipHeight +
-                    tooltipMargin}px, 0)`,
-            });
-    }
-};
-
 const TooltipElement = styled('div')<TooltipElementProps>`
     position: absolute;
     box-sizing: border-box;
@@ -171,7 +64,14 @@ const TooltipElement = styled('div')<TooltipElementProps>`
     ${({ wrap = true }) => css({ whiteSpace: wrap ? 'normal' : 'nowrap' })};
     ${({ maxWidth = 'auto' }) => css({ width: maxWidth })};
     ${({ position, height, width, toolTipHeight, toolTipWidth }) =>
-        positionVariants(position, height, width, toolTipHeight, toolTipWidth)};
+        positionVariants(
+            position,
+            height,
+            width,
+            toolTipHeight,
+            toolTipWidth,
+            8
+        )};
 `;
 
 export class Tooltip extends React.Component<
@@ -215,14 +115,20 @@ export class Tooltip extends React.Component<
             className,
             children,
             content,
-            position,
+            position = 'topEnd',
             wrap,
             background,
             color,
             maxWidth,
             ...props
         } = this.props;
-        const { height, width, toolTipHeight, toolTipWidth } = this.state;
+        const {
+            height,
+            width,
+            hidden,
+            toolTipHeight,
+            toolTipWidth,
+        } = this.state;
         return (
             <ToolTipContainer
                 content={content}
@@ -235,10 +141,10 @@ export class Tooltip extends React.Component<
                 {children}
                 <TooltipElement
                     className={classNames('anchor-tooltip-element', {
-                        active: !this.state.hidden,
+                        active: !hidden,
                     })}
                     ref={this.tooltipRef}
-                    position={position || 'topEnd'}
+                    position={position}
                     height={height}
                     width={width}
                     toolTipHeight={toolTipHeight}

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -64,6 +64,8 @@ storiesOf('Components/Tooltip', module)
                         )}
                         content={text('Tooltip Text', 'Text')}
                         maxWidth={text('Tooltip width', 'auto')}
+                        delay={text('Tooltip delay', '') || undefined}
+                        background={text('Tooltip background', '') || undefined}
                     >
                         <Button size="lg">Hover over me</Button>
                     </Tooltip>

--- a/src/utils/position/position.ts
+++ b/src/utils/position/position.ts
@@ -1,0 +1,105 @@
+import { css } from '@xstyled/styled-components';
+
+export type Position =
+    | 'topStart'
+    | 'top'
+    | 'topEnd'
+    | 'rightStart'
+    | 'right'
+    | 'rightEnd'
+    | 'bottomEnd'
+    | 'bottom'
+    | 'bottomStart'
+    | 'leftEnd'
+    | 'left'
+    | 'leftStart';
+
+export const positionVariants = (
+    position: Position,
+    height: number,
+    width: number,
+    overlayHeight: number,
+    overlayWidth: number,
+    spacing: number = 0
+) => {
+    switch (position) {
+        case 'topStart':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(0, -${overlayHeight + spacing}px, 0)`,
+            });
+        case 'top':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(${width / 2 -
+                    overlayWidth / 2}px, -${overlayHeight + spacing}px, 0)`,
+            });
+        case 'rightStart':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(${width + spacing}px, 0, 0)`,
+            });
+        case 'right':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(${width + spacing}px, ${height / 2 -
+                    overlayHeight / 2}px, 0)`,
+            });
+        case 'rightEnd':
+            return css({
+                left: 0,
+                bottom: 0,
+                transform: `translate3d(${width + spacing}px, 0, 0)`,
+            });
+        case 'bottomEnd':
+            return css({
+                right: 0,
+                top: 0,
+                transform: `translate3d(0, ${height + spacing}px, 0)`,
+            });
+        case 'bottom':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(${width / 2 -
+                    overlayWidth / 2}px, ${height + spacing}px, 0)`,
+            });
+        case 'bottomStart':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(0, ${height + spacing}px, 0)`,
+            });
+        case 'leftEnd':
+            return css({
+                left: 0,
+                bottom: 0,
+                transform: `translate3d(-${overlayWidth + spacing}px, 0, 0)`,
+            });
+        case 'left':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(-${overlayWidth + spacing}px, ${height /
+                    2 -
+                    overlayHeight / 2}px, 0)`,
+            });
+        case 'leftStart':
+            return css({
+                left: 0,
+                top: 0,
+                transform: `translate3d(-${overlayWidth + spacing}px, 0, 0)`,
+            });
+        case 'topEnd':
+        default:
+            return css({
+                right: 0,
+                top: 0,
+                transform: `translate3d(0, -${overlayHeight + spacing}px, 0)`,
+            });
+    }
+};


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
