### PR TITLE
feat(Input): Variantize input sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ node_modules
 
 # Editors
 .idea
-# .vscode
+.vscode
 
 # Folders
 .cache

--- a/src/AutoComplete/__snapshots__/AutoComplete.component.spec.tsx.snap
+++ b/src/AutoComplete/__snapshots__/AutoComplete.component.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Component: AutoComplete should be defined 1`] = `
   display: block;
   position: relative;
   border: solid thin #D3D3D3;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   cursor: text;
   box-sizing: border-box;
   min-width: 5rem;
@@ -14,11 +14,6 @@ exports[`Component: AutoComplete should be defined 1`] = `
   overflow: hidden;
   height: 3.125rem;
   padding: 0.25rem;
-}
-
-.c1 input {
-  height: 1rem;
-  font-size: 1rem;
 }
 
 .c1::-webkit-input-placeholder {
@@ -59,6 +54,11 @@ exports[`Component: AutoComplete should be defined 1`] = `
   -webkit-transform: translate(0,0) scale(1);
   -ms-transform: translate(0,0) scale(1);
   transform: translate(0,0) scale(1);
+}
+
+.c1 input {
+  height: 1rem;
+  font-size: 1rem;
 }
 
 .c3 {
@@ -183,7 +183,7 @@ exports[`Component: AutoComplete should render with a shadow 1`] = `
   display: block;
   position: relative;
   border: solid thin #D3D3D3;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   cursor: text;
   box-sizing: border-box;
   min-width: 5rem;
@@ -192,11 +192,6 @@ exports[`Component: AutoComplete should render with a shadow 1`] = `
   overflow: hidden;
   height: 3.125rem;
   padding: 0.25rem;
-}
-
-.c1 input {
-  height: 1rem;
-  font-size: 1rem;
 }
 
 .c1::-webkit-input-placeholder {
@@ -237,6 +232,11 @@ exports[`Component: AutoComplete should render with a shadow 1`] = `
   -webkit-transform: translate(0,0) scale(1);
   -ms-transform: translate(0,0) scale(1);
   transform: translate(0,0) scale(1);
+}
+
+.c1 input {
+  height: 1rem;
+  font-size: 1rem;
 }
 
 .c3 {
@@ -361,7 +361,7 @@ exports[`Component: AutoComplete should render with a suffix and prefix 1`] = `
   display: block;
   position: relative;
   border: solid thin #D3D3D3;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   cursor: text;
   box-sizing: border-box;
   min-width: 5rem;
@@ -370,11 +370,6 @@ exports[`Component: AutoComplete should render with a suffix and prefix 1`] = `
   overflow: hidden;
   height: 3.125rem;
   padding: 0.25rem;
-}
-
-.c1 input {
-  height: 1rem;
-  font-size: 1rem;
 }
 
 .c1::-webkit-input-placeholder {
@@ -415,6 +410,11 @@ exports[`Component: AutoComplete should render with a suffix and prefix 1`] = `
   -webkit-transform: translate(0,0) scale(1);
   -ms-transform: translate(0,0) scale(1);
   transform: translate(0,0) scale(1);
+}
+
+.c1 input {
+  height: 1rem;
+  font-size: 1rem;
 }
 
 .c3 {
@@ -548,7 +548,7 @@ exports[`Component: AutoComplete should render without a border 1`] = `
   display: block;
   position: relative;
   border: solid thin #D3D3D3;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   cursor: text;
   box-sizing: border-box;
   min-width: 5rem;
@@ -557,11 +557,6 @@ exports[`Component: AutoComplete should render without a border 1`] = `
   overflow: hidden;
   height: 3.125rem;
   padding: 0.25rem;
-}
-
-.c1 input {
-  height: 1rem;
-  font-size: 1rem;
 }
 
 .c1::-webkit-input-placeholder {
@@ -602,6 +597,11 @@ exports[`Component: AutoComplete should render without a border 1`] = `
   -webkit-transform: translate(0,0) scale(1);
   -ms-transform: translate(0,0) scale(1);
   transform: translate(0,0) scale(1);
+}
+
+.c1 input {
+  height: 1rem;
+  font-size: 1rem;
 }
 
 .c3 {

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -3,9 +3,10 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
+import { th, variant } from '@xstyled/system';
 // COMPONENTS
 import { Typography } from '../../Typography';
+import { INPUT_THEME, INPUT_KEY } from './utils';
 // UTILS
 import { get } from '../../utils/get/get';
 
@@ -77,41 +78,12 @@ interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
     onFocus?: InputEventHandler;
 }
 
-const InputSizeDimensions = {
-    sm: css`
-        height: 2.5rem;
-
-        input {
-            height: 1rem;
-            font-size: 0.875rem;
-        }
-    `,
-    md: css`
-        height: 3.125rem;
-        padding: 0.25rem;
-
-        input {
-            height: 1rem;
-            font-size: 0.875rem;
-        }
-    `,
-    lg: css`
-        height: 3.125rem;
-        padding: 0.25rem;
-
-        input {
-            height: 1rem;
-            font-size: 1rem;
-        }
-    `,
-};
-
 const StyledInputWrapper = styled('div')<InputProps>`
     // Input Display Size
     display: block;
     position: relative;
     border: solid thin ${th.color('borders.base')};
-    border-radius: 0.25rem;
+    border-radius: base;
     cursor: text;
     box-sizing: border-box;
     min-width: 5rem;
@@ -120,15 +92,13 @@ const StyledInputWrapper = styled('div')<InputProps>`
     // TODO: delete
     overflow: hidden;
 
-    ${({ size = 'md' }: InputProps) => InputSizeDimensions[size]};
-
     ::placeholder {
         font-family: ${th('typography.fontFamily')};
         color: text.placeholder;
     }
 
     &.focus {
-        border-color: ${th.color('borders.dark')};
+        border-color: borders.dark;
     }
 
     label {
@@ -139,6 +109,13 @@ const StyledInputWrapper = styled('div')<InputProps>`
             transform: translate(0, 0) scale(1);
         }
     }
+
+    ${variant({
+        key: `${INPUT_KEY}.sizes`,
+        prop: 'size',
+        default: 'md',
+        variants: INPUT_THEME.sizes,
+    })}
 `;
 
 const StyledReversedInputContainer = styled('div')`

--- a/src/Form/Input/index.ts
+++ b/src/Form/Input/index.ts
@@ -1,1 +1,2 @@
 export { Input } from './Input.component';
+export { INPUT_KEY, INPUT_THEME } from './utils';

--- a/src/Form/Input/utils.ts
+++ b/src/Form/Input/utils.ts
@@ -1,0 +1,31 @@
+export const INPUT_KEY = 'inputs';
+export const INPUT_THEME = {
+    sizes: {
+        sm: {
+            height: '2.5rem',
+
+            input: {
+                height: '1rem',
+                fontSize: '0.875rem',
+            },
+        },
+        md: {
+            height: '3.125rem',
+            padding: '0.25rem',
+
+            input: {
+                height: '1rem',
+                fontSize: '0.875rem',
+            },
+        },
+        lg: {
+            height: '3.125rem',
+            padding: '0.25rem',
+
+            input: {
+                height: '1rem',
+                fontSize: '1rem',
+            },
+        },
+    },
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -20,11 +20,13 @@ export { NormalizeCSS, GlobalCSS } from './GlobalStyles';
 // TODO: ============================================================ move all of these ^ consts to a different location
 
 import { BUTTON_KEY, BUTTON_THEME } from '../Button';
+import { INPUT_KEY, INPUT_THEME } from '../Form/Input/utils';
 
 export const RootTheme = {
     typography,
     radii: { none: '0', base: '4px', modal: '8px', circular: '1000px' },
     [BUTTON_KEY]: BUTTON_THEME,
+    [INPUT_KEY]: INPUT_THEME,
     colors: ColorsTheme,
     breakpoints: {
         xs: 0,


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Makes the input size variants part of the theme. I did this during prep for the conference demo, so I made a PR out of it.