### PR TITLE
docs: Updates to Tooltip and DropDown

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
         "gatsby-plugin-typescript": "^2.0.13",
         "gatsby-source-filesystem": "^2.0.33",
         "gatsby-transformer-sharp": "^2.1.19",
+        "html-react-parser": "^0.9.1",
         "prism-react-renderer": "^0.1.7",
         "react": "^16.9.0",
         "react-copy-to-clipboard": "^5.0.1",

--- a/docs/src/components/DropDownExample/DropDownExample.component.tsx
+++ b/docs/src/components/DropDownExample/DropDownExample.component.tsx
@@ -10,9 +10,23 @@ import { MyList } from './MyList.component';
 import { MouseOverMe } from './MouseOverMe.component';
 
 export const DropDownExample = () => (
-    <DropDown overlay={<MyList />} position={{ left: 0 }}>
-        <MouseOverMe color={colors.white.base}>
-            Seriously, Mouse Over Me
-        </MouseOverMe>
-    </DropDown>
+    <div>
+        <DropDown
+            arrowIndent="0.75rem"
+            arrowSize="0.625rem"
+            background="white"
+            border="light"
+            borderRadius="base"
+            shadow="0 0 0.5rem 0 rgba(0,0,0,0.2)"
+            overlay={<MyList />}
+            position="bottom"
+            showArrow={true}
+            spacing="0.75rem"
+            trigger="hover"
+        >
+            <MouseOverMe color={colors.white.base}>
+                Seriously, Mouse Over Me
+            </MouseOverMe>
+        </DropDown>
+    </div>
 );

--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -32,7 +32,7 @@ interface PageProps {
 
 // Defining this in one location so that it can be used both in the table styles for the pre tag,
 // and for the StyledInlineCode component fed to MDX's custom Components.
-const InlineCodeStyle = css`
+export const InlineCodeStyle = css`
     display: inline;
     background-color: rgba(27, 31, 35, 0.05);
     font-family: 'SFMono-Regular', Consolas, Liberation Mono, Menlo, Courier,
@@ -49,47 +49,48 @@ const StyledContentMain = styled('main')`
     padding-top: 1rem;
     padding-bottom: 3rem;
 
-    table {
+    table.api {
         width: 100%;
         font-family: ${fonts.fontFamily};
         margin: 1rem 0;
-    }
-    th {
-        text-align: left;
-        padding: 0.75rem 0.5rem;
-        border-bottom: solid thin ${colors.ash.light};
-        background-color: ${colors.white.base};
-    }
-    tr {
-        &:nth-child(odd) {
-            background-color: ${colors.silver.light};
-        }
-    }
-    td {
-        padding: 0.75rem 0.5rem;
-        line-height: 1.5rem;
 
-        &:first-child {
-            font-family: monospace;
-            color: ${colors.flashPink.dark};
-            width: 10%;
-        }
-        &:nth-child(2) {
-            width: 60%;
-        }
-        &:nth-child(3) {
-            font-family: monospace;
-            color: ${colors.cyberMango.dark};
-            width: 20%;
-        }
-        &:nth-child(4) {
+        th {
             text-align: left;
-            font-family: monospace;
-            width: 10%;
+            padding: 0.75rem 0.5rem;
+            border-bottom: solid thin ${colors.ash.light};
+            background-color: ${colors.white.base};
         }
+        tr {
+            &:nth-child(odd) {
+                background-color: ${colors.silver.light};
+            }
+        }
+        td {
+            padding: 0.75rem 0.5rem;
+            line-height: 1.5rem;
 
-        pre {
-            ${InlineCodeStyle};
+            &:first-child {
+                font-family: monospace;
+                color: ${colors.flashPink.dark};
+                width: 10%;
+            }
+            &:nth-child(2) {
+                width: 60%;
+            }
+            &:nth-child(3) {
+                font-family: monospace;
+                color: ${colors.cyberMango.dark};
+                width: 20%;
+            }
+            &:nth-child(4) {
+                text-align: left;
+                font-family: monospace;
+                width: 10%;
+            }
+
+            pre {
+                ${InlineCodeStyle};
+            }
         }
     }
 

--- a/docs/src/components/Utils/ApiTable.component.tsx
+++ b/docs/src/components/Utils/ApiTable.component.tsx
@@ -1,0 +1,161 @@
+/*
+    This component is used to render a formatted html table with API information for a given
+    component. The user can opt to either use this table, or simply use semantic table tags to draw
+    the page.
+
+    If a table cell is left empty it will cause a crash in Gatsby, which is why all fields are
+    enforced via typescript. The exception is default, which if left out a '-' will be entered into
+    the td that would be rendered.
+
+    The description field can accept strings (which can contain html tags interpreted with
+    html-react-parser), a React component, or an array with a mix of both. The last option is useful
+    in situations where a combination of components and custom text is needed as html-react-parser
+    will end up rendering passed components as [Object, object].
+
+    Ex:
+
+    <ApiTable data={[
+        {
+            property: 'background',
+            description: [
+                <ColorBlurb label="DropDown" background gradient />,
+                ` Note that changing this value changes both the arrow color and the background
+                color of the <pre>DropDown</pre>, so using anything other than solid colors can have
+                unexpected results.`
+            ],
+            type: 'string',
+            default: 'light',
+        },
+        {
+            property: 'color',
+            description: <ColorBlurb label="Example Component" />,
+            type: 'string',
+            default: 'black',
+        },
+        {
+            property: 'title',
+            description: 'Title for this <pre>Component</pre>.',
+            type: 'string',
+        },
+    ]} />
+
+    TODO: Eventually remove the semantic table option from the site and the styles associated with
+    it.
+*/
+
+// REACT
+import * as React from 'react';
+// VENDOR
+import styled from '@xstyled/styled-components';
+import { th } from '@xstyled/system';
+import parse from 'html-react-parser';
+// ANCHOR & COMPONENTS
+import { colors } from '@retailmenot/anchor';
+import { InlineCodeStyle } from '../Layout/Page/Page.component';
+
+const Table = styled('table')`
+    width: 100%;
+    font-family: ${th('typography.fontFamily')};
+    margin: 1rem 0;
+
+    th {
+        text-align: left;
+        padding: 0.75rem 0.5rem;
+        border-bottom: solid thin ${colors.ash.light};
+        background-color: ${colors.white.base};
+    }
+    tr {
+        &:nth-child(odd) {
+            background-color: ${colors.silver.light};
+        }
+    }
+    td {
+        padding: 0.75rem 0.5rem;
+        line-height: 1.5rem;
+
+        &:first-child {
+            font-family: monospace;
+            color: ${colors.flashPink.dark};
+            width: 10%;
+        }
+        &:nth-child(2) {
+            width: 60%;
+        }
+        &:nth-child(3) {
+            font-family: monospace;
+            color: ${colors.cyberMango.dark};
+            width: 20%;
+        }
+        &:nth-child(4) {
+            text-align: left;
+            font-family: monospace;
+            width: 10%;
+            white-space: nowrap;
+        }
+
+        pre {
+            ${InlineCodeStyle};
+        }
+    }
+`;
+
+interface ApiTableProps {
+    data: [];
+}
+
+interface RowData {
+    property: string;
+    /* There are several utility components that could be passed as a description in addition to a
+    plain string. Also an option is to pass an array of values in order to combine both plain text
+    and components.  */
+    description: string | [] | React.ReactElement;
+    type: string;
+    default?: string;
+}
+
+export const ApiTable = ({ data }: ApiTableProps): React.ReactElement<any> => (
+    <Table>
+        <thead>
+            <tr>
+                <th>Property</th>
+                <th>Description</th>
+                <th>Type</th>
+                <th>Default</th>
+            </tr>
+        </thead>
+        <tbody>
+            {data &&
+                data.map(
+                    (rowData: RowData): React.ReactElement<any> => (
+                        <tr key={`key-${rowData.property}`}>
+                            <td>{rowData.property}</td>
+                            <td>
+                                {Array.isArray(rowData.description)
+                                    ? rowData.description.map(
+                                          (description, i) => (
+                                              <React.Fragment key={`key-${i}`}>
+                                                  {typeof description ===
+                                                  'string'
+                                                      ? parse(
+                                                            description
+                                                        )
+                                                      : description}
+                                              </React.Fragment>
+                                          )
+                                      )
+                                    : typeof rowData.description === 'string'
+                                    ? parse(rowData.description)
+                                    : rowData.description}
+                            </td>
+                            <td>{rowData.type}</td>
+                            <td>
+                                {rowData.default
+                                    ? parse(rowData.default)
+                                    : '-'}
+                            </td>
+                        </tr>
+                    )
+                )}
+        </tbody>
+    </Table>
+);

--- a/docs/src/components/Utils/ColorBlurb.component.tsx
+++ b/docs/src/components/Utils/ColorBlurb.component.tsx
@@ -30,8 +30,12 @@ export const ColorBlurb = ({
         <pre>{label}</pre>.
         {defaultTheme ? (
             <Typography pl="1">
-                It uses <Link to="/theme/colors"><pre>colors</pre></Link> from <strong>Anchor</strong> by
-                default, but any valid CSS color value can be provided
+                It uses{' '}
+                <Link to="/theme/colors">
+                    <pre>colors</pre>
+                </Link>{' '}
+                from <strong>Anchor</strong> by default, but any valid CSS color
+                value can be provided
                 {background && gradient && ', including gradients'}.
             </Typography>
         ) : (

--- a/docs/src/components/Utils/FormatTypes.component.tsx
+++ b/docs/src/components/Utils/FormatTypes.component.tsx
@@ -7,11 +7,15 @@
     Requires an array of values to iterate over. It's smart enough to render single quotes around
     strings and no quotes around numbers. If the 'noInterpret' prop is passed, it won't make any
     assumptions and will output exactly what is in the array without escaping content using
-    dangerouslySetInnerHTML.
+    html-react-parser.
 */
 
+// REACT
 import * as React from 'react';
+// VENDOR
 import styled from '@xstyled/styled-components';
+import parse from 'html-react-parser';
+// ANCHOR
 import { colors } from '@retailmenot/anchor';
 
 const StyledFormatTypes = styled('div')`
@@ -47,8 +51,9 @@ export const FormatTypes = ({
                         <span
                             key={type}
                             className="type"
-                            dangerouslySetInnerHTML={{ __html: type }}
-                        />
+                        >
+                            {parse(type)}
+                        </span>
                     );
                 }
 

--- a/docs/src/components/Utils/PositionGrid.component.tsx
+++ b/docs/src/components/Utils/PositionGrid.component.tsx
@@ -1,0 +1,139 @@
+/*
+    Inspired by https://material-ui.com/components/tooltips/#tooltips
+
+    Renders a diagram using a formatted table to illustrate to the user what our position values
+    (top, topStart, bottom, bottemEnd, etc) mean for absolutely positioned elements for components
+    like Tooltip and DropDown.
+*/
+
+import * as React from 'react';
+import styled from '@xstyled/styled-components';
+import { th } from '@xstyled/system';
+import { Tooltip } from '@retailmenot/anchor';
+
+const StyledPositionGrid = styled('div')`
+    text-align: center;
+    padding: 1rem 0;
+`;
+
+const StyledTable = styled('table')`
+    padding: 1rem;
+    background-color: ${th('colors.neutrals.silver.base')};
+    display: inline-block;
+    width: auto;
+    margin: 0 auto;
+    border-collapse: collapse;
+
+    td {
+        width: 10rem;
+        padding: 0.75rem 0.25rem;
+        font-family: ${th('typography.fontFamily')};
+        font-size: 1.25rem;
+    }
+`;
+
+const SpanHover = styled('span')`
+    cursor: pointer;
+`;
+
+const TdLeft = styled('td')`
+    text-align: left;
+`;
+
+const TdRight = styled('td')`
+    text-align: right;
+`;
+
+const TdColoredBlock = styled('td')`
+    background-color: ${th('colors.neutrals.ash.light')};
+`;
+
+interface EasyTooltipProps {
+    children: any;
+    vertical?: boolean;
+}
+
+const EasyTooltip = ({
+    children,
+    vertical,
+}: EasyTooltipProps): React.ReactElement<any> => (
+    <Tooltip
+        position={children}
+        content={'Example content.'}
+        maxWidth={vertical ? '5rem' : '10rem'}
+    >
+        <SpanHover>{children}</SpanHover>
+    </Tooltip>
+);
+
+export const PositionGrid = () => (
+    <StyledPositionGrid>
+        <StyledTable>
+            <tbody>
+                <tr>
+                    <TdLeft />
+                    <td>
+                        <EasyTooltip>topStart</EasyTooltip>
+                    </td>
+                    <td>
+                        <EasyTooltip>top</EasyTooltip>
+                    </td>
+                    <td>
+                        <EasyTooltip>topEnd</EasyTooltip>
+                    </td>
+                    <TdRight />
+                </tr>
+
+                <tr>
+                    <TdLeft>
+                        <EasyTooltip vertical>leftStart</EasyTooltip>
+                    </TdLeft>
+                    <TdColoredBlock />
+                    <TdColoredBlock />
+                    <TdColoredBlock />
+                    <TdRight>
+                        <EasyTooltip vertical>rightStart</EasyTooltip>
+                    </TdRight>
+                </tr>
+
+                <tr>
+                    <TdLeft>
+                        <EasyTooltip vertical>left</EasyTooltip>
+                    </TdLeft>
+                    <TdColoredBlock />
+                    <TdColoredBlock />
+                    <TdColoredBlock />
+                    <TdRight>
+                        <EasyTooltip vertical>right</EasyTooltip>
+                    </TdRight>
+                </tr>
+
+                <tr>
+                    <TdLeft>
+                        <EasyTooltip vertical>leftEnd</EasyTooltip>
+                    </TdLeft>
+                    <TdColoredBlock />
+                    <TdColoredBlock />
+                    <TdColoredBlock />
+                    <TdRight>
+                        <EasyTooltip vertical>rightEnd</EasyTooltip>
+                    </TdRight>
+                </tr>
+
+                <tr>
+                    <TdLeft />
+                    <td>
+                        <EasyTooltip>bottomStart</EasyTooltip>
+                    </td>
+                    <td>
+                        <EasyTooltip>bottom</EasyTooltip>
+                    </td>
+                    <td>
+                        <EasyTooltip>bottomEnd</EasyTooltip>
+                    </td>
+                    <TdRight />
+                </tr>
+            </tbody>
+        </StyledTable>
+    </StyledPositionGrid>
+);

--- a/docs/src/components/Utils/SiteLink.component.tsx
+++ b/docs/src/components/Utils/SiteLink.component.tsx
@@ -24,13 +24,11 @@ interface SiteLinkProps {
     to: string;
 }
 
-export const SiteLink = ({children, to}: SiteLinkProps): React.ReactElement<any> => (
+export const SiteLink = ({
+    children,
+    to,
+}: SiteLinkProps): React.ReactElement<any> => (
     <StyledSiteLink to={to}>
-        {children
-        ?
-            children
-        :
-            <span>View &raquo;</span>
-        }
+        {children ? children : <span>View &raquo;</span>}
     </StyledSiteLink>
 );

--- a/docs/src/components/Utils/index.ts
+++ b/docs/src/components/Utils/index.ts
@@ -1,5 +1,7 @@
 export { FormatTypes } from './FormatTypes.component';
-export { ColorBlurb } from './ColorBlurb';
+export { ColorBlurb } from './ColorBlurb.component';
 export { ComponentInfo } from './ComponentInfo.component';
 export { sections } from './sections';
 export { SiteLink } from './SiteLink.component';
+export { PositionGrid } from './PositionGrid.component';
+export { ApiTable } from './ApiTable.component';

--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -155,7 +155,7 @@ props.
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -31,7 +31,7 @@ The props `src` and `label` are not intended to be used simultaneously.
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/badge.mdx
+++ b/docs/src/pages/components/badge.mdx
@@ -136,7 +136,7 @@ export const BadgeWithParentExample = () => {
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/button.mdx
+++ b/docs/src/pages/components/button.mdx
@@ -120,7 +120,7 @@ below. Also included is an example of an icon button*
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/card.mdx
+++ b/docs/src/pages/components/card.mdx
@@ -103,7 +103,7 @@ Now that we've created these separate components, lets organize them into a `Car
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/collapse.mdx
+++ b/docs/src/pages/components/collapse.mdx
@@ -53,7 +53,7 @@ The **`CollapseGroup`** component combines multiple **`Collapse`** components to
 
 ### Collapse
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -116,7 +116,7 @@ The **`CollapseGroup`** component combines multiple **`Collapse`** components to
 
 ### CollapseGroup
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/dropdown.mdx
+++ b/docs/src/pages/components/dropdown.mdx
@@ -1,6 +1,12 @@
 import { Link } from 'gatsby';
 import { DropDownExample } from './../../components/DropDownExample';
-import { ComponentInfo, FormatTypes } from '../../components/Utils';
+import {
+    ApiTable,
+    ColorBlurb,
+    ComponentInfo,
+    FormatTypes,
+    PositionGrid
+} from '../../components/Utils';
 
 # DropDown
 
@@ -10,7 +16,12 @@ import { ComponentInfo, FormatTypes } from '../../components/Utils';
 
 <DropDownExample />
 
-<br />
+<br /><br />
+
+The `DropDown` has 12 possible placements via the `position` prop. These placements are based on the
+motion and direction of the content and less about exact positioning. The diagram below illustrates:
+
+<PositionGrid />
 
 ---
 
@@ -19,7 +30,8 @@ import { ComponentInfo, FormatTypes } from '../../components/Utils';
 Since this component is designed to show/hide other components lets go ahead and make a couple of
 components to give us some styling and and a 'menu' that will appear. First, lets make the component
 that will be hovered over to show the `overlay`. This is a simple styled component that's extending
-**Anchor**'s <Link to="/components/typography/">`Typography`</Link> component to give it a little more pop.
+**Anchor**'s <Link to="/components/typography/">`Typography`</Link> component to give it a little
+more pop.
 
 Note that we're importing **Anchor**'s `colors` object for all of the examples to follow.
 Refer to the <Link to="/theme/colors">colors</Link> section for more information.
@@ -78,8 +90,17 @@ together with `DropDown`!
 
 ```jsx live
 <DropDown
+    arrowIndent="0.75rem"
+    arrowSize="0.625rem"
+    background="white"
+    border="light"
+    borderRadius="base"
+    shadow="0 0 0.5rem 0 rgba(0,0,0,0.2)"
     overlay={<MyList />}
-    position={{ top:40, left: 0 }}
+    position="bottom"
+    showArrow={true}
+    spacing="0.75rem"
+    trigger="hover"
 >
     <MouseOverMe color={colors.white.base}>
         Seriously, Mouse Over Me
@@ -91,36 +112,101 @@ together with `DropDown`!
 
 ## API
 
-<table>
-    <thead>
-        <tr>
-            <th>Property</th>
-            <th>Description</th>
-            <th>Type</th>
-            <th>Default</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>overlay</td>
-            <td>
-                The content that will be displayed when the child node is hovered
-                over. This can be a single React element, or an array of React elements.
-            </td>
-            <td>
-                React Element | Array
-            </td>
-            <td>-</td>
-        </tr>
-        <tr>
-            <td>position</td>
-            <td>
-                This positions the overlay relative to the top-left corner of the <pre>DropDown</pre>
-                component. Parameters are passed via object allowing multiple parameters to be sent,
-                i.e. <pre>&#123; top: 10, left: 20 &#125;</pre>. Values are treated as <pre>px</pre>.
-            </td>
-            <td>object, <FormatTypes types={['top', 'right', 'bottom', 'left']} /></td>
-            <td>&#123; top: [outer height of DropDown], left: 0 &#125;</td>
-        </tr>
-    </tbody>
-</table>
+<ApiTable data={[
+    {
+        property: 'arrowIndent',
+        description: `How far the arrow should be indented relative to the <pre>DropDown</pre> content.
+            This setting works with all <pre>position</pre>'s
+            except <pre>bottom</pre>, <pre>top</pre>, <pre>right</pre> or <pre>left</pre>. Any valid
+            CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.75rem',
+    },
+    {
+        property: 'arrowSize',
+        description: `How large the arrow will be. Note that extremely large values will distort the
+            arrow. Any valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.625rem',
+    },
+    {
+        property: 'background',
+        description: [
+            <ColorBlurb label="DropDown" background gradient />,
+            ` Note that changing this value changes both the arrow color and the background color of
+            the <pre>DropDown</pre>, so using anything other than solid colors can have unexpected
+            results.`
+        ],
+        type: 'string',
+        default: 'white',
+    },
+    {
+        property: 'border',
+        description: `The border that appears around the <pre>DropDown</pre>. This prop uses values
+            from RootTheme, <pre>base</pre>, <pre>light</pre> or <pre>dark</pre>, but it also can
+            accept any CSS border shorthand, ex: <pre>solid green 0.25rem</pre>`,
+        type: 'string',
+        default: 'light',
+    },
+    {
+        property: 'borderRadius',
+        description: `The radius of the border around the <pre>DropDown</pre>. This prop uses values
+            from RootTheme, <pre>base</pre>, <pre>circular</pre>, <pre>none</pre> or <pre>modal</pre>,
+            but it also can accept any CSS <pre>border-radius</pre> shorthand, ex: <pre>1rem 0.5rem</pre>`,
+        type: 'string',
+        default: 'base',
+    },
+    {
+        property: 'overlay',
+        description: `The content that will be displayed when the child node is hovered
+            over. This can be a single React element, or an array of React elements.`,
+        type: 'React Element | Array',
+    },
+    {
+        property: 'position',
+        description: `This positions the overlay based on the diagram provided at the top of this
+            document`,
+        type: <FormatTypes
+                types={[
+                    'topStart',
+                    'top',
+                    'topEnd',
+                    'rightStart',
+                    'right',
+                    'rightEnd',
+                    'bottomEnd',
+                    'bottom',
+                    'bottomStart',
+                    'leftEnd',
+                    'left',
+                    'leftStart',
+                ]} />,
+        default: 'bottom'
+    },
+    {
+        property: 'shadow',
+        description: `The dropshadow that appears beneath the <pre>DropDown</pre>.`,
+        type: 'string',
+        default: '0 0 0.5rem 0 rgba(0,0,0,0.2)',
+    },
+    {
+        property: 'showArrow',
+        description: `Whether or not the arrow should be displayed.`,
+        type: 'boolean',
+        default: 'true',
+    },
+    {
+        property: 'spacing',
+        description: `The distance the <pre>DropDown</pre> will be from the contained element. Any
+            valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted. If <pre>showArrow</pre> is
+            set to false, the default value is <pre>0</pre>.`,
+        type: 'string',
+        default: '0.75rem',
+    },
+    {
+        property: 'trigger',
+        description: `What triggers the show/hide of the <pre>DropDown</pre>.`,
+        type: <FormatTypes types={['both', 'click', 'hover']} />,
+        default: 'both',
+    },
+]} />

--- a/docs/src/pages/components/hero.mdx
+++ b/docs/src/pages/components/hero.mdx
@@ -49,7 +49,7 @@ from **Anchor** as well as the <Link to="/components/button/">`Button`</Link> co
 
 ### Hero
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -111,7 +111,7 @@ from **Anchor** as well as the <Link to="/components/button/">`Button`</Link> co
 Editable props are `tag`  and `weight`. Refer to <Link to="/components/typography">`Typography`</Link> for
 more information.
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -163,7 +163,7 @@ more information.
 `Subtitle` is as a wrapper of the `Typography` component. Editable props are `scale` and`weight`.
 Refer to `Typography`'s <Link to="/components/typography">documentation</Link> for more information.
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/icon.mdx
+++ b/docs/src/pages/components/icon.mdx
@@ -34,7 +34,7 @@ There are currently <IconCount /> icons available. Note that you can try any of 
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/input.mdx
+++ b/docs/src/pages/components/input.mdx
@@ -50,7 +50,7 @@ The below example shows a way in which you can attach your own methods to these 
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/list.mdx
+++ b/docs/src/pages/components/list.mdx
@@ -135,7 +135,7 @@ const myItems = [
 
 ### List
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -165,7 +165,7 @@ const myItems = [
 
 ### ListDivider
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -215,7 +215,7 @@ const myItems = [
 
 ### ListItem
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -313,7 +313,7 @@ const myItems = [
 
 ### ListTitle
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/menu.mdx
+++ b/docs/src/pages/components/menu.mdx
@@ -27,7 +27,7 @@ import { ComponentInfo, FormatTypes, ColorBlurb } from '../../components/Utils';
 
 ### Menu
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -79,7 +79,7 @@ import { ComponentInfo, FormatTypes, ColorBlurb } from '../../components/Utils';
 
 ### MenuItem
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/modal.mdx
+++ b/docs/src/pages/components/modal.mdx
@@ -195,7 +195,7 @@ And voila! Here is our `PageExample` component rendered with our `ModalAndButton
 
 The `Modal` component is based off of `styled-react-modal` and as such accepts any of those <Typography tag="a" href="https://github.com/AlexanderRichey/styled-react-modal#modal" target="_blank">props</Typography>.
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -276,7 +276,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
 
 ### Header
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -320,7 +320,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
 
 ### Footer
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>
@@ -356,7 +356,7 @@ The `Modal` component is based off of `styled-react-modal` and as such accepts a
 
 ### Close
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/components/tooltip.mdx
+++ b/docs/src/pages/components/tooltip.mdx
@@ -1,107 +1,92 @@
-import { ComponentInfo, FormatTypes } from '../../components/Utils';
+import {
+    ApiTable,
+    ColorBlurb,
+    ComponentInfo,
+    FormatTypes,
+    PositionGrid,
+} from '../../components/Utils';
 
 # Tooltip
 
 <ComponentInfo title="Tooltip" mode="description" />
 
-```jsx
-import { Tooltip } from '@retailmenot/anchor';
-```
+The `Tooltip` has 12 possible placements via the `position` prop. These placements are based on the
+motion and direction of the content and less about exact positioning. The diagram below illustrates:
 
-<br />
+<PositionGrid />
 
 ```tsx live
-<Tooltip content="Tooltip">
+<Tooltip
+    background={colors.charcoal.dark}
+    color={colors.cyberMango.light}
+    content="Here is some lovely content."
+    display="inline-block"
+    maxWidth="10rem"
+    position="right"
+    wrap="true"
+>
     <Button>Hover over me</Button>
 </Tooltip>
 ```
 
-<br />
-
-## API's
-
 ---
 
-### Tooltip
+## API
 
-<table>
-    <thead>
-        <tr>
-            <th>Property</th>
-            <th>Description</th>
-            <th>Type</th>
-            <th>Default</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>position</td>
-            <td>Property for the position of the Tooltip.</td>
-            <td>
-                <FormatTypes
-                    types={[
-                        'topStart',
-                        'top',
-                        'topEnd',
-                        'rightStart',
-                        'right',
-                        'rightEnd',
-                        'bottomEnd',
-                        'bottom',
-                        'bottomStart',
-                        'leftEnd',
-                        'left',
-                        'leftStart',
-                    ]}
-                />
-            </td>
-            <td>
-                <pre>topEnd</pre>
-            </td>
-        </tr>
-        <tr>
-            <td>maxWidth</td>
-            <td>Property for the maximum width of the Tooltip.</td>
-            <td>string</td>
-            <td>
-                <pre>auto</pre>
-            </td>
-        </tr>
-        <tr>
-            <td>wrap</td>
-            <td>Property to control the text wrap of the Tooltip.</td>
-            <td>boolean</td>
-            <td>
-                <pre>false</pre>
-            </td>
-        </tr>
-        <tr>
-            <td>background</td>
-            <td>CSS property for the background.</td>
-            <td>string</td>
-            <td>
-                <pre>rgba(0, 0, 0, 0.8)</pre>
-            </td>
-        </tr>
-        <tr>
-            <td>color</td>
-            <td>CSS property for the text color.</td>
-            <td>string</td>
-            <td>
-                <pre>white</pre>
-            </td>
-        </tr>
-        <tr>
-            <td>content</td>
-            <td>Property for the text of the Tooltip.</td>
-            <td>string</td>
-            <td>-</td>
-        </tr>
-        <tr>
-            <td>display</td>
-            <td>Property for the display of the tooltip container.</td>
-            <td>string</td>
-            <td>-</td>
-        </tr>
-    </tbody>
-</table>
+<ApiTable data={[
+    {
+        property: 'background',
+        description: <ColorBlurb label="Tooltip" background gradient />,
+        type: 'string',
+        default: 'rgba(0, 0, 0, 0.8)',
+    },
+    {
+        property: 'color',
+        description: <ColorBlurb label="Tooltip" />,
+        type: 'string',
+        default: 'white',
+    },
+    {
+        property: 'content',
+        description: 'The text that will appear in the <pre>Tooltip</pre>.',
+        type: 'string',
+    },
+    {
+        property: 'display',
+        description: `CSS property for the <pre>display</pre> of the <pre>Tooltip</pre> container.
+            Note that changing this value can affect the position of the content.`,
+        type: 'string',
+    },
+    {
+        property: 'maxWidth',
+        description: `Property for the maximum width of the <pre>Tooltip</pre>.`,
+        type: 'string',
+        default: 'auto',
+    },
+    {
+        property: 'position',
+        description: `Where the tooltip should appear when the child element is hovered.`,
+        type: <FormatTypes
+                types={[
+                    'topStart',
+                    'top',
+                    'topEnd',
+                    'rightStart',
+                    'right',
+                    'rightEnd',
+                    'bottomEnd',
+                    'bottom',
+                    'bottomStart',
+                    'leftEnd',
+                    'left',
+                    'leftStart',
+                ]} />,
+        default: 'topEnd',
+    },
+    {
+        property: 'wrap',
+        description: `Whether the content of the tooltip will wrap to the next line.`,
+        type: 'boolean',
+        default: 'false',
+    },
+]}/>

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -39,7 +39,7 @@ These are the default styles for Typography:
 
 ## API
 
-<table>
+<table class="api">
     <thead>
         <tr>
             <th>Property</th>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 // VENDOR
 import styled, { createGlobalStyle } from '@xstyled/styled-components';
 import { Link, withPrefix } from 'gatsby';
-import {
-    ThemeProvider,
-    RootTheme,
-} from '@retailmenot/anchor';
+import { ThemeProvider, RootTheme } from '@retailmenot/anchor';
 // COMPONENTS
 import { HomeTopNav } from '../components/Navigation/HomeTopNav';
 import { Wave } from '../components/Wave';
@@ -61,7 +58,7 @@ const StyledCards = styled('section')`
     max-width: ${CONTENT_WIDTH}px;
     margin: 0 auto;
     display: flex;
-    padding-top:4rem;
+    padding-top: 4rem;
 `;
 
 const Column = styled('div')`
@@ -81,29 +78,29 @@ const StyledOcean = styled('div')`
     height: 28rem;
     width: 100%;
     position: absolute;
-    bottom:0;
-    left:0;
-    right:0;
-    overflow:hidden;
-    z-index:-1;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    overflow: hidden;
+    z-index: -1;
 `;
 
 const StyledFooter = styled('footer')`
     width: 100%;
-    display:block;
+    display: block;
     position: absolute;
-    bottom:2rem;
-    left:0;
-    right:0;
-    text-align:center;
-    z-index:30;
+    bottom: 2rem;
+    left: 0;
+    right: 0;
+    text-align: center;
+    z-index: 30;
 
     img {
-        display:block;
+        display: block;
     }
 
     a {
-        display:inline-block;
+        display: inline-block;
         padding: 0 1rem;
     }
 `;
@@ -158,13 +155,13 @@ export const IndexPage = (): React.ReactElement<any> => (
             </StyledOcean>
 
             <StyledFooter>
-                    <a href="//retailmenot.com" target="_blank">
-                        <img src={withPrefix('/images/r-mark.svg')} />
-                    </a>
-                    <a href="//github.com/RetailMeNot/anchor" target="_blank">
-                        <img src={withPrefix('/images/octocat.svg')} />
-                    </a>
-                </StyledFooter>
+                <a href="//retailmenot.com" target="_blank">
+                    <img src={withPrefix('/images/r-mark.svg')} />
+                </a>
+                <a href="//github.com/RetailMeNot/anchor" target="_blank">
+                    <img src={withPrefix('/images/octocat.svg')} />
+                </a>
+            </StyledFooter>
         </StyledIndexPage>
     </ThemeProvider>
 );

--- a/docs/src/typings.d.ts
+++ b/docs/src/typings.d.ts
@@ -25,6 +25,7 @@ declare module '@retailmenot/anchor' {
   const Search: any;
   const sizes: any;
   const ThemeProvider: any;
+  const Tooltip: any;
   const Typography: any;
 }
 
@@ -45,4 +46,111 @@ declare module '@xstyled/styled-components' {
 
     const styled: StyledInterface;
     export default styled;
+}
+
+declare module '@xstyled/system' {
+  export const breakpoints: any;
+  export const th: any;
+
+  export const variant: <T extends {}>({
+      key,
+      default: defaultValue,
+      variants,
+      prop,
+  }: {
+      key?: string;
+      default: string | number;
+      variants?: {
+          [key: string]: T;
+          [key: number]: T;
+      };
+      prop?: string;
+  }) => (props: any) => any;
+
+  export const compose: any;
+
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/styled-system/index.d.ts
+  import * as CSS from 'csstype';
+
+  export type TLengthStyledSystem = string | 0 | number;
+  export type ResponsiveValue<T> = T | { [key: string]: T };
+
+  export interface SpaceProps<TLength = TLengthStyledSystem> {
+      m?: ResponsiveValue<CSS.MarginProperty<TLength>>;
+      margin?: ResponsiveValue<CSS.MarginProperty<TLength>>;
+      mt?: ResponsiveValue<CSS.MarginTopProperty<TLength>>;
+      marginTop?: ResponsiveValue<CSS.MarginTopProperty<TLength>>;
+      mr?: ResponsiveValue<CSS.MarginRightProperty<TLength>>;
+      marginRight?: ResponsiveValue<CSS.MarginRightProperty<TLength>>;
+      mb?: ResponsiveValue<CSS.MarginBottomProperty<TLength>>;
+      marginBottom?: ResponsiveValue<CSS.MarginBottomProperty<TLength>>;
+      ml?: ResponsiveValue<CSS.MarginLeftProperty<TLength>>;
+      marginLeft?: ResponsiveValue<CSS.MarginLeftProperty<TLength>>;
+      mx?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+      my?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+      p?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+      padding?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+      pt?: ResponsiveValue<CSS.PaddingTopProperty<TLength>>;
+      paddingTop?: ResponsiveValue<CSS.PaddingTopProperty<TLength>>;
+      pr?: ResponsiveValue<CSS.PaddingRightProperty<TLength>>;
+      paddingRight?: ResponsiveValue<CSS.PaddingRightProperty<TLength>>;
+      pb?: ResponsiveValue<CSS.PaddingBottomProperty<TLength>>;
+      paddingBottom?: ResponsiveValue<CSS.PaddingBottomProperty<TLength>>;
+      pl?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>>;
+      paddingLeft?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>>;
+      px?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+      py?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
+  }
+
+  export interface MarginProps
+      extends Pick<
+          SpaceProps,
+          | 'm'
+          | 'margin'
+          | 'mt'
+          | 'marginTop'
+          | 'mb'
+          | 'marginBottom'
+          | 'ml'
+          | 'marginLeft'
+          | 'mr'
+          | 'marginRight'
+          | 'my'
+          | 'mx'
+      > {}
+  export interface PaddingProps
+      extends Pick<
+          SpaceProps,
+          | 'p'
+          | 'padding'
+          | 'pt'
+          | 'paddingTop'
+          | 'pb'
+          | 'paddingBottom'
+          | 'pl'
+          | 'paddingLeft'
+          | 'pr'
+          | 'paddingRight'
+          | 'py'
+          | 'px'
+      > {}
+
+  export interface ColorProps {
+      color?: ResponsiveValue<CSS.ColorProperty>;
+  }
+  export interface BackgroundColorProps<TLength = TLengthStyledSystem> {
+      backgroundColor?: ResponsiveValue<CSS.BackgroundProperty<TLength>>;
+  }
+
+  export interface StyleFn {
+      (...args: any[]): any;
+      propTypes?: string[];
+  }
+
+  export const color: StyleFn;
+  export const backgroundColor: StyleFn;
+
+  export const space: StyleFn;
+  export const margin: StyleFn;
+  export const padding: StyleFn;
 }

--- a/src/Tooltip/Tooltip.component.tsx
+++ b/src/Tooltip/Tooltip.component.tsx
@@ -14,7 +14,7 @@ interface TooltipContainerProps extends React.HTMLAttributes<HTMLDivElement> {
     maxWidth?: string;
     background?: string;
     color?: string;
-    wrap?: boolean;
+    wrapContent?: boolean;
     display?: string;
     delay?: string;
 }
@@ -38,7 +38,7 @@ interface TooltipElementProps {
     width: number;
     toolTipHeight: number;
     toolTipWidth: number;
-    wrap?: boolean;
+    wrapContent?: boolean;
     background?: string;
     color?: string;
     maxWidth?: string;
@@ -70,7 +70,8 @@ const TooltipElement = styled('div')<TooltipElementProps>`
         visibility: visible;
     }
 
-    ${({ wrap = true }) => css({ whiteSpace: wrap ? 'normal' : 'nowrap' })};
+    ${({ wrapContent = true }) =>
+        css({ whiteSpace: wrapContent ? 'normal' : 'nowrap' })};
     ${({ maxWidth = 'auto' }) => css({ width: maxWidth })};
     ${({ position, height, width, toolTipHeight, toolTipWidth }) =>
         positionVariants(
@@ -125,7 +126,7 @@ export class Tooltip extends React.Component<
             children,
             content,
             position = 'topEnd',
-            wrap,
+            wrapContent,
             background,
             color,
             maxWidth,
@@ -161,7 +162,7 @@ export class Tooltip extends React.Component<
                     toolTipHeight={toolTipHeight}
                     toolTipWidth={toolTipWidth}
                     children={content}
-                    wrap={wrap}
+                    wrapContent={wrapContent}
                     background={background}
                     color={color}
                     maxWidth={maxWidth}

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -30,7 +30,7 @@ storiesOf('Components/Tooltip', module)
                 <>
                     <Typography tag="h1">Tool Tip Demo</Typography>
                     <Tooltip
-                        wrap={boolean('Tooltip wrap', false)}
+                        wrapContent={boolean('Tooltip wrap', false)}
                         position={select<
                             | 'topStart'
                             | 'top'


### PR DESCRIPTION
docs(PositionGrid): new component, helps illustrate the positions of tooltip/dropdown

docs(ApiTable): new component to hopefully replace straight html tables being used for api section

docs(tooltip): Updated API table with more consistent wording/formatting

chore: prettier

chore: updated to v0.0.1-beta.18

fix(Tooltip): renamed wrap to wrapContent as wrap is a reserved html attribute

fix(DropDownExample): changed position from object to string, 'bottom'

fix(ColorBlurb): renamed file ColorBlurb to ColorBlurb.component

docs(DropDown): Added the PositionGrid component

docs(DropDownExample): added in all props from DropDown

docs(dropdown): Added ApiTable component, added in new props

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

- Updates documentation on `DropDown`
- Updates documentation on `Tooltip`
- Updates Anchor to v0.0.1-beta.18
- Adds `ApiTable` component to eventually replace semantic table tags and related css
- Adds `PositionGrid` component to demonstrate absolute positioning in Anchor
