### PR TITLE
fix: Fixes export warnings in the Gatsby build

### DIFF
--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -9,9 +9,9 @@ import { filter, map, mapTo, distinctUntilChanged } from 'rxjs/operators';
 // ANCHOR
 import { get } from '../utils/get/get';
 import { Arrow } from './Arrow/Arrow.component';
-import { positionVariants, Position } from '../utils/position/position';
+import { positionVariants, Position } from '../utils/position';
 
-export { Position } from '../utils/position/position';
+export type Position = Position;
 export type Trigger = 'hover' | 'click' | 'both';
 
 interface DropDownProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/src/Tooltip/Tooltip.component.tsx
+++ b/src/Tooltip/Tooltip.component.tsx
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
 import { th } from '@xstyled/system';
 // ANCHOR
-import { positionVariants, Position } from '../utils/position/position';
-export { Position } from '../utils/position/position';
+import { positionVariants, Position } from '../utils/position';
+export type Position = Position;
 
 interface TooltipContainerProps extends React.HTMLAttributes<HTMLDivElement> {
     content: string;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [ ] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

More explicitly states the export `type` of `Position`.
