### PR TITLE
fix(NextPrevious): declared state values outside of constructor

### DIFF
--- a/docs/src/components/Navigation/NextPrevious/NextPrevious.component.tsx
+++ b/docs/src/components/Navigation/NextPrevious/NextPrevious.component.tsx
@@ -41,6 +41,11 @@ interface State {
 }
 
 class NextPrevious extends React.PureComponent<NextPreviousProps> {
+    state = {
+        next: undefined,
+        previous: undefined,
+    };
+
     constructor(props: NextPreviousProps) {
         super(props);
         // Received from the AddLocation HOC
@@ -51,7 +56,7 @@ class NextPrevious extends React.PureComponent<NextPreviousProps> {
         });
 
         if (currentSection) {
-            const { links } = currentSection;
+            const { links }: LinkProperties = currentSection;
             // Gets the index of the this page's link entry in the section
             const indexOfLink = links.reduce(
                 (currentIndex: number, link: LinkProperties, index: number) => {


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [ ] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
