### PR TITLE
fix(Typography): fix scale precedence, dedup redundant styles, remove margins, hue prop

### DIFF
--- a/docs/src/components/HomeCard/HomeCard.component.tsx
+++ b/docs/src/components/HomeCard/HomeCard.component.tsx
@@ -40,7 +40,7 @@ const StyledHomeCard = styled('div')<HomeCardProps>`
                 box-sizing: border-box;
                 content: 'Coming Soon';
                 display: block;
-                font-family: ${th('typography.fontFamily')};
+                font-family: base;
                 padding: 0.5rem 1rem 0.5rem 2.4rem;
                 position: absolute;
                 right: -2.75rem;

--- a/docs/src/components/TemplateExample/ExampleLink.component.tsx
+++ b/docs/src/components/TemplateExample/ExampleLink.component.tsx
@@ -9,7 +9,7 @@ const StyledExampleLink = styled('a')`
     font-weight: bold;
     font-size: 1.25rem;
     text-decoration: none;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 `;
 
 export const ExampleLink = (props: any): React.ReactElement<any> => (

--- a/docs/src/components/Utils/ApiTable/ApiTable.component.tsx
+++ b/docs/src/components/Utils/ApiTable/ApiTable.component.tsx
@@ -54,7 +54,7 @@ import { InlineCodeStyle } from '../../Layout/Page/Page.component';
 
 const Table = styled('table')`
     width: 100%;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     margin: 1rem 0;
 
     th {

--- a/docs/src/components/Utils/ComponentInfo/ComponentInfo.component.tsx
+++ b/docs/src/components/Utils/ComponentInfo/ComponentInfo.component.tsx
@@ -31,7 +31,7 @@ const TitleLink = styled('a')`
     line-height: 1.5rem;
     font-weight: 600;
     color: inherit;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 
     &:hover {
         text-decoration: underline;

--- a/docs/src/components/Utils/PositionGrid/PositionGrid.component.tsx
+++ b/docs/src/components/Utils/PositionGrid/PositionGrid.component.tsx
@@ -27,7 +27,7 @@ const StyledTable = styled('table')`
     td {
         width: 10rem;
         padding: 0.75rem 0.25rem;
-        font-family: ${th('typography.fontFamily')};
+        font-family: base;
         font-size: 1.25rem;
     }
 `;

--- a/docs/src/components/Utils/SiteLink.component.tsx
+++ b/docs/src/components/Utils/SiteLink.component.tsx
@@ -19,7 +19,7 @@ interface SiteLinkProps {
 
 const StyledSiteLink = styled(Link)`
     color: #007ecd;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     text-decoration: none;
     font-weight: 600;
 `;

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -30,7 +30,7 @@ These are the default styles for Typography:
     <Typography tag="p">
         The quick <Typography tag="span" transform="uppercase" color="#ff0000" weight="bolder">red</Typography> fox
     </Typography>
-    <Typography tag="h2" color="charcoal" hue="light">
+    <Typography tag="h2" color="neutrals.charcoal.light">
         jumped
     </Typography>
     <Typography tag="p">
@@ -54,10 +54,8 @@ These are the default styles for Typography:
     {
         property: 'color',
         description: [
-            `Sets the font color. Accepts any valid CSS color value. If you use one of
-            <strong>Anchor</strong>'s `,
-            <Link to="/theme/colors/">theme</Link>,
-            ` colors, you'll be able to control its hue via a prop noted below.`
+            `Sets the font color. Accepts any valid CSS color value. Will use values present in the colors
+            <Link to="/theme/colors/">theme</Link>.`
         ],
         type: <FormatTypes data={['string', 'rgb', 'rgba']} noInterpret />,
         default: 'inherit',
@@ -86,15 +84,6 @@ These are the default styles for Typography:
             <pre><a href="https://www.w3schools.com/tags/att_for.asp" target="_blank">for</a></pre>
             html attribute in order to associate the label to a form element.`,
         type: 'string',
-    },
-    {
-        property: 'hue',
-        description: [
-            `If the <pre>color</pre> prop is set to one of <strong>Anchor</strong>'s `,
-            <Link to="/theme/colors/">theme</Link>,
-            ` colors, allows changing that color's hue.`
-        ],
-        type: <FormatTypes data={['light', 'base', 'dark']} />,
     },
     {
         property: 'lineHeight',

--- a/docs/src/pages/contribute/basictemplate.mdx
+++ b/docs/src/pages/contribute/basictemplate.mdx
@@ -49,7 +49,7 @@ Documentation on how to use the code block and live code editor are available in
     <Typography tag="p">
         The quick <Typography tag="span" transform="uppercase" color="#ff0000" weight="bolder">red</Typography> fox
     </Typography>
-    <Typography tag="h2" color="charcoal" hue="light">
+    <Typography tag="h2" color="neutrals.charcoal.light">
         jumped
     </Typography>
     <Typography tag="p">

--- a/docs/src/pages/contribute/exampletemplate.mdx
+++ b/docs/src/pages/contribute/exampletemplate.mdx
@@ -117,7 +117,7 @@ const StyledExampleLink = styled('a')`
     font-weight:bold;
     font-size:1.25rem;
     text-decoration:none;
-    font-family: ${th('typography.fontFamily')}
+    font-family: base
 `;
 
 export const ExampleLink = (props: any): React.ReactElement<any> =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/scripts/MyComponent/MyComponent.stories.tsx
+++ b/scripts/MyComponent/MyComponent.stories.tsx
@@ -12,7 +12,7 @@ import { MyComponent } from './MyComponent.component';
 const StyledStory = styled('div')`
     padding: 2rem;
     color: text.body;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 `;
 
 storiesOf('Components/MyComponentPath', module).add('Default', () => (

--- a/src/Alert/Alert.component.tsx
+++ b/src/Alert/Alert.component.tsx
@@ -7,7 +7,6 @@ import styled, {
     FlattenInterpolation,
     ThemeProps,
 } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 import { darken } from 'polished';
 // COMPONENTS
 import { Close } from '../Icon';
@@ -63,7 +62,7 @@ const StyledAlert = styled('div')<AlertProps>`
     box-sizing: border-box;
     position: relative;
     border-radius: base;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     padding: 0.5rem 1.5rem 0.5rem 0.5rem;
     ${({ variant }) =>
         css({

--- a/src/Alert/Alert.component.tsx
+++ b/src/Alert/Alert.component.tsx
@@ -110,7 +110,7 @@ const renderMessageAndDescription = ({
     <>
         {message && <Typography tag="h4">{message}</Typography>}
         {description && (
-            <Typography tag="p" color="charcoal" hue="light">
+            <Typography tag="p" color="neutrals.charcoal.light">
                 {description}
             </Typography>
         )}

--- a/src/Alert/Alert.stories.tsx
+++ b/src/Alert/Alert.stories.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 import { select, boolean, text } from '@storybook/addon-knobs';
 // ANCHOR
 import { RootTheme } from '../../src/theme';
@@ -14,7 +13,7 @@ import { InfoOutline } from '../Icon';
 const StyledStory = styled('div')`
     padding: 2rem;
     color: text.body;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 `;
 
 storiesOf('Components/Alert', module)

--- a/src/Alert/__snapshots__/Alert.spec.tsx.snap
+++ b/src/Alert/__snapshots__/Alert.spec.tsx.snap
@@ -47,12 +47,12 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 
@@ -144,12 +144,12 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 
@@ -249,12 +249,12 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 
@@ -346,12 +346,12 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 
@@ -451,12 +451,12 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 
@@ -548,12 +548,12 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 
@@ -649,12 +649,12 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 
@@ -746,12 +746,12 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin-bottom: 1rem;
   color: #595959;
 }
 

--- a/src/Alert/__snapshots__/Alert.spec.tsx.snap
+++ b/src/Alert/__snapshots__/Alert.spec.tsx.snap
@@ -56,9 +56,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c1 small {
@@ -71,7 +71,7 @@ Array [
   >
     <p
       className="c1 anchor-typography"
-      color="charcoal"
+      color="neutrals.charcoal.light"
     >
       Test Description
     </p>
@@ -158,9 +158,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c3 small {
@@ -207,7 +207,7 @@ Array [
       >
         <p
           className="c3 anchor-typography"
-          color="charcoal"
+          color="neutrals.charcoal.light"
         >
           Test Description
         </p>
@@ -268,9 +268,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c1 small {
@@ -283,7 +283,7 @@ Array [
   >
     <p
       className="c1 anchor-typography"
-      color="charcoal"
+      color="neutrals.charcoal.light"
     >
       Test Description
     </p>
@@ -370,9 +370,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c3 small {
@@ -419,7 +419,7 @@ Array [
       >
         <p
           className="c3 anchor-typography"
-          color="charcoal"
+          color="neutrals.charcoal.light"
         >
           Test Description
         </p>
@@ -480,9 +480,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c1 small {
@@ -495,7 +495,7 @@ Array [
   >
     <p
       className="c1 anchor-typography"
-      color="charcoal"
+      color="neutrals.charcoal.light"
     >
       Test Description
     </p>
@@ -582,9 +582,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c3 small {
@@ -627,7 +627,7 @@ Array [
       >
         <p
           className="c3 anchor-typography"
-          color="charcoal"
+          color="neutrals.charcoal.light"
         >
           Test Description
         </p>
@@ -688,9 +688,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c1 small {
@@ -703,7 +703,7 @@ Array [
   >
     <p
       className="c1 anchor-typography"
-      color="charcoal"
+      color="neutrals.charcoal.light"
     >
       Test Description
     </p>
@@ -790,9 +790,9 @@ Array [
   font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 1rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c3 small {
@@ -840,7 +840,7 @@ Array [
       >
         <p
           className="c3 anchor-typography"
-          color="charcoal"
+          color="neutrals.charcoal.light"
         >
           Test Description
         </p>

--- a/src/Alert/__snapshots__/Alert.spec.tsx.snap
+++ b/src/Alert/__snapshots__/Alert.spec.tsx.snap
@@ -47,18 +47,13 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c1 small {
@@ -149,18 +144,13 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c3 small {
@@ -259,18 +249,13 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c1 small {
@@ -361,18 +346,13 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c3 small {
@@ -471,18 +451,13 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c1 small {
@@ -573,18 +548,13 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c3 small {
@@ -679,18 +649,13 @@ Array [
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c1 small {
@@ -781,18 +746,13 @@ Array [
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  text-align: inherit;
+  color: inherit;
   margin-bottom: 1rem;
   color: #595959;
-  text-align: inherit;
-  text-transform: none;
 }
 
 .c3 small {

--- a/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
+++ b/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
@@ -119,9 +119,9 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c2 small {
@@ -136,9 +136,9 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c4 small {
@@ -159,7 +159,7 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
     >
       <span
         className="c2 anchor-typography c3 lg"
-        color="charcoal"
+        color="neutrals.charcoal.light"
       >
         Result Item 1
       </span>
@@ -172,7 +172,7 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
     >
       <span
         className="c4 anchor-typography c3 lg"
-        color="charcoal"
+        color="neutrals.charcoal.light"
       >
         Result Item 2
       </span>
@@ -316,9 +316,9 @@ exports[`Component: ResultsContainer should be defined 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c3 small {
@@ -333,9 +333,9 @@ exports[`Component: ResultsContainer should be defined 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c5 small {
@@ -357,7 +357,7 @@ exports[`Component: ResultsContainer should be defined 1`] = `
     >
       <span
         className="c3 anchor-typography c4 lg"
-        color="charcoal"
+        color="neutrals.charcoal.light"
       >
         Result Item 1
       </span>
@@ -371,7 +371,7 @@ exports[`Component: ResultsContainer should be defined 1`] = `
     >
       <span
         className="c5 anchor-typography c4 lg"
-        color="charcoal"
+        color="neutrals.charcoal.light"
       >
         Result Item 2
       </span>

--- a/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
+++ b/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
@@ -115,13 +115,11 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: #595959;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  color: #595959;
 }
 
 .c2 small {
@@ -132,13 +130,11 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: #595959;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  color: #595959;
 }
 
 .c4 small {
@@ -312,13 +308,11 @@ exports[`Component: ResultsContainer should be defined 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: #595959;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  color: #595959;
 }
 
 .c3 small {
@@ -329,13 +323,11 @@ exports[`Component: ResultsContainer should be defined 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: #595959;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  color: #595959;
 }
 
 .c5 small {

--- a/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
+++ b/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
@@ -114,6 +114,7 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
 .c2 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;
@@ -129,6 +130,7 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
 .c4 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;
@@ -307,6 +309,7 @@ exports[`Component: ResultsContainer should be defined 1`] = `
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;
@@ -322,6 +325,7 @@ exports[`Component: ResultsContainer should be defined 1`] = `
 .c5 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;

--- a/src/Avatar/Avatar.component.tsx
+++ b/src/Avatar/Avatar.component.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 
 interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
     className?: string;
@@ -49,7 +48,7 @@ const InnerBorder = styled('div')`
     flex: 0 0 1.625rem;
     width: 1.625rem;
     height: 1.625rem;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     font-size: 0.75rem;
     font-weight: bold;
     color: text.body;

--- a/src/Badge/Badge.component.tsx
+++ b/src/Badge/Badge.component.tsx
@@ -51,7 +51,7 @@ const BadgeSizeStyles: BadgeStylesGroup = {
 // TODO: this encapsulation may be redundant
 const StyledBadgeContainer = styled('div')<BadgeProps>`
     position: relative;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     display: inline-block;
 `;
 

--- a/src/Card/Card.component.tsx
+++ b/src/Card/Card.component.tsx
@@ -23,7 +23,7 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 const StyledCard = styled('div')<CardProps>`
     position: relative;
     width: 100%;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     box-sizing: border-box;
     border-radius: base;
     border: solid thin ${th.color('borders.base')};

--- a/src/Card/Card.stories.tsx
+++ b/src/Card/Card.stories.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 // COMPONENTS
 import { Card } from './Card.component';
 import { DropDown } from '../DropDown';
@@ -19,7 +18,7 @@ import * as README from './README.md';
 const StyledStory = styled('div')`
     h2,
     h3 {
-        font-family: ${th('typography.fontFamily')};
+        font-family: base;
         font-weight: normal;
         color: text.body;
         margin-bottom: 0.5rem;

--- a/src/Card/CardAction/CardAction.component.tsx
+++ b/src/Card/CardAction/CardAction.component.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 
 export interface CardActionProps extends React.HTMLAttributes<HTMLDivElement> {
     className?: string;
@@ -16,7 +15,7 @@ const StyledCard = styled('div')<CardActionProps>`
     display: flex;
     justify-content: center;
     align-items: center;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     top: 0;
     right: 0;
     width: 2.5rem;

--- a/src/Card/CardAction/__snapshots__/CardAction.component.spec.tsx.snap
+++ b/src/Card/CardAction/__snapshots__/CardAction.component.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: CardAction should be defined 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  font-family: base;
   top: 0;
   right: 0;
   width: 2.5rem;

--- a/src/Card/CardActionArea/CardActionArea.component.tsx
+++ b/src/Card/CardActionArea/CardActionArea.component.tsx
@@ -16,7 +16,7 @@ const StyledCardActionArea = styled('div')<CardActionAreaProps>`
     box-sizing: border-box;
     position: relative;
     display: inline-block;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     width: 100%;
     border-top: solid thin ${th.color('neutrals.silver.dark')};
     ${({ backgroundColor = 'neutrals.white.base' }: CardActionAreaProps) =>

--- a/src/Card/CardActionArea/__snapshots__/CardActionArea.component.spec.tsx.snap
+++ b/src/Card/CardActionArea/__snapshots__/CardActionArea.component.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`Component: CardActionArea should be defined 1`] = `
   box-sizing: border-box;
   position: relative;
   display: inline-block;
+  font-family: base;
   width: 100%;
   border-top: solid thin neutrals.silver.dark;
   background-color: neutrals.white.base;

--- a/src/Card/CardContent/CardContent.component.tsx
+++ b/src/Card/CardContent/CardContent.component.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 // COMPONENTS
 import { Gutters } from '../Card.component';
 
@@ -26,7 +25,7 @@ const StyledCard = styled('div')<CardContentProps>`
     display: block;
     padding: ${({ gutter = 'medium' }: CardContentProps) =>
         gutterSizes[gutter]};
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 `;
 
 export const CardContent: React.FunctionComponent<CardContentProps> = ({

--- a/src/Card/CardContent/__snapshots__/CardContent.component.spec.tsx.snap
+++ b/src/Card/CardContent/__snapshots__/CardContent.component.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`Component: CardContent should be defined 1`] = `
   position: relative;
   display: block;
   padding: 1rem;
+  font-family: base;
 }
 
 <div

--- a/src/Card/__snapshots__/Card.component.spec.tsx.snap
+++ b/src/Card/__snapshots__/Card.component.spec.tsx.snap
@@ -6,11 +6,13 @@ exports[`Component: Card should match its snapshot. 1`] = `
   position: relative;
   display: block;
   padding: 1rem;
+  font-family: base;
 }
 
 .c0 {
   position: relative;
   width: 100%;
+  font-family: base;
   box-sizing: border-box;
   border-radius: base;
   border: solid thin borders.base;

--- a/src/Collapse/Collapse.component.tsx
+++ b/src/Collapse/Collapse.component.tsx
@@ -138,7 +138,7 @@ const variantStyles = createVariant({
 const StyledCollapse = styled('div')<StyledCollapseProps>`
     display: block;
     box-sizing: border-box;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 
     ${variantStyles}
 

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -48,7 +48,7 @@ interface StyledDropDownProps extends DropDownProps {
 
 const StyledDropDown = styled('div')<StyledDropDownProps>`
     box-sizing: border-box;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     position: relative;
     cursor: pointer;
     display: inline-flex;

--- a/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
+++ b/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
@@ -19,6 +19,7 @@ exports[`Component: DropDown should render in the DOM 1`] = `
 
 .c0 {
   box-sizing: border-box;
+  font-family: base;
   position: relative;
   cursor: pointer;
   display: -webkit-inline-box;

--- a/src/Form/ControlLabel/__snapshots__/ControlLabel.spec.tsx.snap
+++ b/src/Form/ControlLabel/__snapshots__/ControlLabel.spec.tsx.snap
@@ -17,6 +17,7 @@ exports[`Component: ControlLabel should be defined 1`] = `
 .c0 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;

--- a/src/Form/ControlLabel/__snapshots__/ControlLabel.spec.tsx.snap
+++ b/src/Form/ControlLabel/__snapshots__/ControlLabel.spec.tsx.snap
@@ -24,11 +24,11 @@ exports[`Component: ControlLabel should be defined 1`] = `
   line-height: 1.5rem;
   font-weight: normal;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   line-height: 1.375rem;
   margin-bottom: 1rem;
-  color: inherit;
 }
 
 .c0 small {

--- a/src/Form/ControlLabel/__snapshots__/ControlLabel.spec.tsx.snap
+++ b/src/Form/ControlLabel/__snapshots__/ControlLabel.spec.tsx.snap
@@ -18,15 +18,10 @@ exports[`Component: ControlLabel should be defined 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
   line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
   line-height: 1.375rem;
   margin-bottom: 1rem;
 }

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -93,7 +93,7 @@ const StyledInputWrapper = styled('div')<InputProps>`
     overflow: hidden;
 
     ::placeholder {
-        font-family: ${th('typography.fontFamily')};
+        font-family: base;
         color: text.placeholder;
     }
 
@@ -160,7 +160,7 @@ const StyledInput = styled('input')<StyledInputProps>`
     color: text.body;
     // TODO: bring this back when the 'bug' in styled components gets sorted out (MVP)
     //transition: all 250ms;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     // Disable Number Spinners
     &[type='number']::-webkit-inner-spin-button,
     &[type='number']::-webkit-outer-spin-button {

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -300,8 +300,7 @@ export const Input = forwardRef(
                         />
                         {label && (
                             <Typography
-                                color="ash"
-                                hue="dark"
+                                color="neutrals.ash.dark"
                                 scale={
                                     focus ||
                                     (inputValue && `${inputValue}`.length)

--- a/src/Form/Toggle/Toggle.component.tsx
+++ b/src/Form/Toggle/Toggle.component.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 const { forwardRef } = React;
 // VENDOR
 import styled, { css } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 import classnames from 'classnames';
 // ANCHOR
 import { space as spaceStyles, SpaceProps } from '@xstyled/system';
@@ -25,7 +24,7 @@ const StyledToggle = styled('label')<ToggleProps>`
     ${spaceStyles}
 
     // Styles for the ON/OFF
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     font-size: 0.75rem;
     line-height: 1rem;
     font-weight: 500;

--- a/src/Hero/README.md
+++ b/src/Hero/README.md
@@ -5,34 +5,36 @@ The Hero component offers two built-in components `Hero.Title` and `Hero.Subtitl
 ## Usage
 
 #### Basic
+
 ```jsx
 import { Hero } from '@retailmenot/anchor';
 const { Title, Subtitle } = Hero;
 
 const basicExample = props => (
-  <Hero background="blue">
-    <Title>Title</Title>
-    <Subtitle>My Subtitle</Subtitle>
-  </Hero>
+    <Hero background="blue">
+        <Title>Title</Title>
+        <Subtitle>My Subtitle</Subtitle>
+    </Hero>
 );
 ```
 
 #### Advanced
+
 ```jsx
 import { Container, SomeImage } from 'my_app/components';
 import { Hero } from '@retailmenot/anchor';
 const { Title, Subtitle } = Hero;
 
 const advancedExample = props => (
-  <Hero align="left" color="charcoal" minHeight="36rem">
-    <Container>
-      <Title>Socks with Sandals</Title>
-      <Subtitle>The best thing since sliced bread!</Subtitle>
-      <Button>Buy Some Today</Button>
+    <Hero align="left" color="neutrals.charcoal.base" minHeight="36rem">
+        <Container>
+            <Title>Socks with Sandals</Title>
+            <Subtitle>The best thing since sliced bread!</Subtitle>
+            <Button>Buy Some Today</Button>
 
-      <SomeImage position="right"/>
-    </Container>
-  </Hero>
+            <SomeImage position="right" />
+        </Container>
+    </Hero>
 );
 ```
 
@@ -40,11 +42,11 @@ const advancedExample = props => (
 
 ### Hero
 
-  * **`background = 'transparent'`**: css property for defining the Hero's background
-  * **`align = 'center'`:** css property for text alignment
-  * **`minHeight = '7.5rem'`:** css property for min-height
-  * **`color = '#fff'`:** css property for text color
-  * **`className`:** Additional className to be added to the Hero element
+-   **`background = 'transparent'`**: css property for defining the Hero's background
+-   **`align = 'center'`:** css property for text alignment
+-   **`minHeight = '7.5rem'`:** css property for min-height
+-   **`color = '#fff'`:** css property for text color
+-   **`className`:** Additional className to be added to the Hero element
 
 ### Hero.Title / Hero.Subtitle
 

--- a/src/Hero/__snapshots__/Hero.spec.tsx.snap
+++ b/src/Hero/__snapshots__/Hero.spec.tsx.snap
@@ -117,18 +117,12 @@ exports[`Component: Hero should render with custom content 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 2rem;
   line-height: 2.5rem;
   font-weight: normal;
-  font-size: 1.75rem;
-  line-height: 2rem;
-  margin: 1rem 0;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  margin: 1rem 0;
   font-weight: 600;
 }
 
@@ -140,13 +134,10 @@ exports[`Component: Hero should render with custom content 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
 }
 
 .c3 small {
@@ -207,18 +198,12 @@ exports[`Component: Hero should render with title 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 2rem;
   line-height: 2.5rem;
   font-weight: normal;
-  font-size: 1.75rem;
-  line-height: 2rem;
-  margin: 1rem 0;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  margin: 1rem 0;
   font-weight: 600;
 }
 
@@ -276,18 +261,12 @@ exports[`Component: Hero should render with title and subtitle 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 2rem;
   line-height: 2.5rem;
   font-weight: normal;
-  font-size: 1.75rem;
-  line-height: 2rem;
-  margin: 1rem 0;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  margin: 1rem 0;
   font-weight: 600;
 }
 
@@ -298,14 +277,11 @@ exports[`Component: Hero should render with title and subtitle 1`] = `
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1.125rem;
   line-height: 1.5rem;
-  color: inherit;
+  font-weight: normal;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
   font-weight: 600;
 }
 

--- a/src/Hero/__snapshots__/Hero.spec.tsx.snap
+++ b/src/Hero/__snapshots__/Hero.spec.tsx.snap
@@ -126,10 +126,10 @@ exports[`Component: Hero should render with custom content 1`] = `
   font-size: 1.75rem;
   line-height: 2rem;
   margin: 1rem 0;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   font-weight: 600;
-  color: inherit;
 }
 
 .c1 small {
@@ -144,9 +144,9 @@ exports[`Component: Hero should render with custom content 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
-  color: inherit;
 }
 
 .c3 small {
@@ -216,10 +216,10 @@ exports[`Component: Hero should render with title 1`] = `
   font-size: 1.75rem;
   line-height: 2rem;
   margin: 1rem 0;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   font-weight: 600;
-  color: inherit;
 }
 
 .c1 small {
@@ -285,10 +285,10 @@ exports[`Component: Hero should render with title and subtitle 1`] = `
   font-size: 1.75rem;
   line-height: 2rem;
   margin: 1rem 0;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   font-weight: 600;
-  color: inherit;
 }
 
 .c1 small {
@@ -303,10 +303,10 @@ exports[`Component: Hero should render with title and subtitle 1`] = `
   line-height: 1.5rem;
   font-size: 1.125rem;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   font-weight: 600;
-  color: inherit;
 }
 
 .c3 small {

--- a/src/Hero/__snapshots__/Hero.spec.tsx.snap
+++ b/src/Hero/__snapshots__/Hero.spec.tsx.snap
@@ -117,12 +117,12 @@ exports[`Component: Hero should render with custom content 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 2rem;
   line-height: 2.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin: 1rem 0;
   font-weight: 600;
 }
 
@@ -133,6 +133,7 @@ exports[`Component: Hero should render with custom content 1`] = `
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;
@@ -198,12 +199,12 @@ exports[`Component: Hero should render with title 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 2rem;
   line-height: 2.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin: 1rem 0;
   font-weight: 600;
 }
 
@@ -261,12 +262,12 @@ exports[`Component: Hero should render with title and subtitle 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 2rem;
   line-height: 2.5rem;
   font-weight: normal;
   text-align: inherit;
   color: inherit;
-  margin: 1rem 0;
   font-weight: 600;
 }
 
@@ -277,6 +278,7 @@ exports[`Component: Hero should render with title and subtitle 1`] = `
 .c3 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-weight: normal;

--- a/src/Layout/Footer/Footer.component.tsx
+++ b/src/Layout/Footer/Footer.component.tsx
@@ -9,7 +9,7 @@ import styled from '@xstyled/styled-components';
 import { th } from '@xstyled/system';
 
 const StyledFooterElement = styled('footer')`
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     font-size: 0.75rem;
     background-color: neutrals.white.base;
     border-bottom: solid 1rem ${th.color('primary.base')};

--- a/src/Layout/Footer/FooterSection/FooterSection.component.tsx
+++ b/src/Layout/Footer/FooterSection/FooterSection.component.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 // VENDOR
 import styled, { css } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 
 const reset = css`
     margin: 0;
@@ -11,7 +10,7 @@ const reset = css`
 
 const StyledFooterSectionElement = styled('section')`
     width: 6.875rem;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     font-size: 0.75rem;
 
     h4 {

--- a/src/Layout/Footer/MobileCTA/MobileCTA.component.tsx
+++ b/src/Layout/Footer/MobileCTA/MobileCTA.component.tsx
@@ -172,8 +172,7 @@ export const MobileCTA = ({
                         tag="p"
                         className="cta-caption"
                         weight={600}
-                        color="savvyCyan"
-                        hue="dark"
+                        color="accent.dark"
                     >
                         Download the App
                     </Typography>

--- a/src/List/Item/Item.component.tsx
+++ b/src/List/Item/Item.component.tsx
@@ -103,8 +103,7 @@ export const Item = ({
     >
         <StyledTypography
             tag="span"
-            color="charcoal"
-            hue="light"
+            color="neutrals.charcoal.light"
             className={size}
         >
             {prefix && React.cloneElement(prefix, { className: 'item-prefix' })}

--- a/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
+++ b/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
@@ -107,9 +107,9 @@ exports[`Component: Item should be defined 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: #595959;
   text-align: inherit;
   text-transform: none;
-  color: #595959;
 }
 
 .c1 small {
@@ -124,7 +124,7 @@ exports[`Component: Item should be defined 1`] = `
 >
   <span
     className="c1 anchor-typography c2 lg"
-    color="charcoal"
+    color="neutrals.charcoal.light"
   >
     Item
   </span>

--- a/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
+++ b/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
@@ -102,6 +102,7 @@ exports[`Component: Item should be defined 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;

--- a/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
+++ b/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
@@ -103,13 +103,11 @@ exports[`Component: Item should be defined 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: #595959;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  color: #595959;
 }
 
 .c1 small {

--- a/src/List/Title/Title.component.tsx
+++ b/src/List/Title/Title.component.tsx
@@ -25,7 +25,7 @@ export const Title = ({
     children,
 }: TitleProps): React.ReactElement<any> => (
     <StyledTitle className={classNames('anchor-list-title', className)}>
-        <Typography weight={700} scale={12} color="ash" hue="dark">
+        <Typography weight={700} scale={12} color="neutrals.ash.dark">
             {children}
         </Typography>
     </StyledTitle>

--- a/src/List/Title/__snapshots__/Title.component.spec.tsx.snap
+++ b/src/List/Title/__snapshots__/Title.component.spec.tsx.snap
@@ -18,15 +18,12 @@ exports[`Component: Title should be defined 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 0.75rem;
   line-height: 1rem;
   font-weight: 500;
-  color: #808080;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
+  color: #808080;
   font-weight: 700;
 }
 

--- a/src/List/Title/__snapshots__/Title.component.spec.tsx.snap
+++ b/src/List/Title/__snapshots__/Title.component.spec.tsx.snap
@@ -18,6 +18,7 @@ exports[`Component: Title should be defined 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 0.75rem;
   line-height: 1rem;
   font-weight: 500;

--- a/src/List/Title/__snapshots__/Title.component.spec.tsx.snap
+++ b/src/List/Title/__snapshots__/Title.component.spec.tsx.snap
@@ -24,10 +24,10 @@ exports[`Component: Title should be defined 1`] = `
   font-size: 0.75rem;
   line-height: 1rem;
   font-weight: 500;
+  color: #808080;
   text-align: inherit;
   text-transform: none;
   font-weight: 700;
-  color: #808080;
 }
 
 .c1 small {
@@ -39,7 +39,7 @@ exports[`Component: Title should be defined 1`] = `
 >
   <span
     className="c1 anchor-typography"
-    color="ash"
+    color="neutrals.ash.dark"
     scale={12}
   >
     Title

--- a/src/Menu/Item/Item.component.tsx
+++ b/src/Menu/Item/Item.component.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 // COMPONENTS
 import { MenuSizeProps } from '../Menu.component';
 
@@ -26,7 +25,7 @@ const StyledItem = styled('a')<ItemProps>`
     align-items: center;
     cursor: pointer;
     text-align: center;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     color: text.body;
     text-decoration: none;
     transition: color 250ms;

--- a/src/Menu/Item/__snapshots__/Item.component.spec.tsx.snap
+++ b/src/Menu/Item/__snapshots__/Item.component.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`Component: Item should be defined 1`] = `
   align-items: center;
   cursor: pointer;
   text-align: center;
+  font-family: base;
   color: text.body;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -49,6 +50,7 @@ exports[`Component: Item should render with label 1`] = `
   align-items: center;
   cursor: pointer;
   text-align: center;
+  font-family: base;
   color: text.body;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/Menu/Menu.component.tsx
+++ b/src/Menu/Menu.component.tsx
@@ -68,10 +68,10 @@ const sizeVariant = variant({
 const StyledMenu = styled('nav')<MenuProps>`
     display: flex;
     width: 100%;
-    ${spaceStyles};
     min-width: 15.625rem;
     margin: 0;
     padding: 0;
+    ${spaceStyles};
 
     ${({ background = 'primary.base' }) =>
         css({

--- a/src/Modal/Header/__snapshots__/Header.spec.tsx.snap
+++ b/src/Modal/Header/__snapshots__/Header.spec.tsx.snap
@@ -26,6 +26,7 @@ exports[`Component: Modal.Header should render with title 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-weight: normal;

--- a/src/Modal/Header/__snapshots__/Header.spec.tsx.snap
+++ b/src/Modal/Header/__snapshots__/Header.spec.tsx.snap
@@ -31,10 +31,10 @@ exports[`Component: Modal.Header should render with title 1`] = `
   line-height: 1.5rem;
   font-size: 1.25rem;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   font-weight: bold;
-  color: inherit;
 }
 
 .c1 small {

--- a/src/Modal/Header/__snapshots__/Header.spec.tsx.snap
+++ b/src/Modal/Header/__snapshots__/Header.spec.tsx.snap
@@ -26,14 +26,11 @@ exports[`Component: Modal.Header should render with title 1`] = `
 .c1 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 1.5rem;
   font-size: 1.25rem;
   line-height: 1.5rem;
-  color: inherit;
+  font-weight: normal;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
   font-weight: bold;
 }
 

--- a/src/Pagination/Pagination.stories.tsx
+++ b/src/Pagination/Pagination.stories.tsx
@@ -5,7 +5,6 @@ import { storiesOf } from '@storybook/react';
 import { boolean, number, select } from '@storybook/addon-knobs';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 // ANCHOR
 import * as Icon from '../Icon';
 import { RootTheme } from '../../src/theme';
@@ -15,7 +14,7 @@ const StyledStory = styled('div')`
     width: 95%;
     padding: 0.5rem;
     color: text.body;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 `;
 
 const ResultsContainer = styled('div')`

--- a/src/Skeleton/Skeleton.stories.tsx
+++ b/src/Skeleton/Skeleton.stories.tsx
@@ -5,7 +5,6 @@ import { storiesOf } from '@storybook/react';
 import { boolean, select, text } from '@storybook/addon-knobs';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
-import { th } from '@xstyled/system';
 // ANCHOR
 import * as README from './README.md';
 import { Typography, Avatar, Button, Close } from '..';
@@ -16,7 +15,7 @@ import { Skeleton } from './Skeleton.component';
 const StyledStory = styled('div')`
     padding: 2rem 4rem;
     color: text.body;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
 `;
 
 const Card = styled('div')`

--- a/src/Tooltip/Tooltip.component.tsx
+++ b/src/Tooltip/Tooltip.component.tsx
@@ -53,7 +53,7 @@ const TooltipElement = styled('div')<TooltipElementProps>`
             color,
         })};
     border-radius: base;
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     font-size: 0.8rem;
     padding: 0.5rem;
     opacity: 0;

--- a/src/Typography/Typography.component.tsx
+++ b/src/Typography/Typography.component.tsx
@@ -3,14 +3,18 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
-import { th, variant } from '@xstyled/system';
+import {
+    //
+    th,
+    variant,
+} from '@xstyled/system';
 // ANCHOR
 import { space as spaceStyles, SpaceProps } from '@xstyled/system';
 // import { colors, Color } from '../theme';
 import { TypographyTags, Scale } from '../theme/typography.theme';
 import { rem } from '../utils/rem/rem';
 
-type FontWeights =
+export type FontWeights =
     | 'normal'
     | 'bold'
     | 'bolder'
@@ -27,7 +31,7 @@ type FontWeights =
     | 'initial'
     | 'inherit';
 
-type TextTransforms =
+export type TextTransforms =
     | 'none'
     | 'capitalize'
     | 'uppercase'
@@ -60,7 +64,14 @@ type DisplayValues =
     | 'initial'
     | 'inherit';
 
-export type TextAlign = 'center' | 'left' | 'right' | 'inherit' | 'justify';
+export type TextAlign =
+    | 'center'
+    | 'left'
+    | 'right'
+    | 'inherit'
+    | 'justify'
+    | 'start'
+    | 'end';
 
 export interface TypographyProps extends SpaceProps, React.HTMLAttributes<any> {
     className?: string;
@@ -80,37 +91,31 @@ export interface TypographyProps extends SpaceProps, React.HTMLAttributes<any> {
 
 const StyledTypography = (tag: TypographyTags) => styled(tag)<TypographyProps>`
     box-sizing: border-box;
+    font-family: base;
 
-    // Global Font Properties
-    font-family: ${th('typography.fontFamily')};
-    font-size: ${th('typography.fontSize')};
-    font-weight: ${th('typography.fontWeight')};
-    line-height: ${th('typography.lineHeight')};
+    // Variant styles
+    ${props =>
+        css({
+            fontSize: th('typography.fontSize'),
+            lineHeight: th('typography.lineHeight'),
+            fontWeight: th('typography.fontWeight'),
+            textAlign: 'inherit',
+            color: 'inherit',
+            ...variant({
+                key: 'typography.tag',
+                default: 'none',
+                prop: 'tag',
+            })(props),
+            ...variant({
+                key: 'typography.scale',
+                default: 'none',
+                prop: 'scale',
+            })(props),
+        })}
 
-    // Use a scale to set size & line-height
-    ${variant({
-        key: 'typography.scale',
-        default: 16,
-        prop: 'scale',
-    })}
-
-    // Apply default styles for element
-    ${variant({
-        key: 'typography.tag',
-        default: 'span',
-        prop: 'tag',
-    })}
-
-    // Prop overrides
-    ${({
-        color = 'inherit',
-        align = 'inherit',
-        display,
-        transform = 'none',
-        lineHeight,
-        size,
-        weight,
-    }) =>
+    // Prop overrides. We don't have any defaults here because then they
+    // would always override the variants above.
+    ${({ color, align, display, transform, lineHeight, size, weight }) =>
         css({
             color,
             textAlign: align,

--- a/src/Typography/Typography.component.tsx
+++ b/src/Typography/Typography.component.tsx
@@ -92,6 +92,7 @@ export interface TypographyProps extends SpaceProps, React.HTMLAttributes<any> {
 const StyledTypography = (tag: TypographyTags) => styled(tag)<TypographyProps>`
     box-sizing: border-box;
     font-family: base;
+    margin: 0;
 
     // Variant styles
     ${props =>

--- a/src/Typography/Typography.component.tsx
+++ b/src/Typography/Typography.component.tsx
@@ -3,14 +3,9 @@ import * as React from 'react';
 // VENDOR
 import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
-import {
-    //
-    th,
-    variant,
-} from '@xstyled/system';
+import { th, variant } from '@xstyled/system';
 // ANCHOR
 import { space as spaceStyles, SpaceProps } from '@xstyled/system';
-// import { colors, Color } from '../theme';
 import { TypographyTags, Scale } from '../theme/typography.theme';
 import { rem } from '../utils/rem/rem';
 

--- a/src/Typography/Typography.component.tsx
+++ b/src/Typography/Typography.component.tsx
@@ -6,7 +6,7 @@ import styled, { css } from '@xstyled/styled-components';
 import { th, variant } from '@xstyled/system';
 // ANCHOR
 import { space as spaceStyles, SpaceProps } from '@xstyled/system';
-import { colors, Color } from '../theme';
+// import { colors, Color } from '../theme';
 import { TypographyTags, Scale } from '../theme/typography.theme';
 import { rem } from '../utils/rem/rem';
 
@@ -72,8 +72,7 @@ export interface TypographyProps extends SpaceProps, React.HTMLAttributes<any> {
     children?: any;
     tag?: TypographyTags;
     weight?: FontWeights;
-    color?: 'inherit' | 'initial' | Color | string;
-    hue?: 'light' | 'base' | 'dark';
+    color?: 'inherit' | 'initial' | string;
     scale?: Scale;
     size?: number;
     lineHeight?: number;
@@ -81,6 +80,7 @@ export interface TypographyProps extends SpaceProps, React.HTMLAttributes<any> {
 
 const StyledTypography = (tag: TypographyTags) => styled(tag)<TypographyProps>`
     box-sizing: border-box;
+
     // Global Font Properties
     font-family: ${th('typography.fontFamily')};
     font-size: ${th('typography.fontSize')};
@@ -101,17 +101,21 @@ const StyledTypography = (tag: TypographyTags) => styled(tag)<TypographyProps>`
         prop: 'tag',
     })}
 
-    // CSS Overrides
-    ${({ align = 'inherit', display, transform = 'none' }) =>
+    // Prop overrides
+    ${({
+        color = 'inherit',
+        align = 'inherit',
+        display,
+        transform = 'none',
+        lineHeight,
+        size,
+        weight,
+    }) =>
         css({
+            color,
             textAlign: align,
-            display: display,
+            display,
             textTransform: transform,
-        })};
-
-    // Override Size & Line Height
-    ${({ lineHeight, size, weight }) =>
-        css({
             lineHeight: rem(lineHeight),
             fontSize: rem(size),
             fontWeight: weight,
@@ -119,10 +123,6 @@ const StyledTypography = (tag: TypographyTags) => styled(tag)<TypographyProps>`
 
     // Spacing
     ${spaceStyles}
-
-    // TODO: colors when theme colors are defined
-    ${({ color = 'inherit', hue = 'base' }) =>
-        css({ color: colors[color] ? colors[color][hue] : color })};
 
     small {
         font-size: 87.5%;

--- a/src/Typography/Typography.component.tsx
+++ b/src/Typography/Typography.component.tsx
@@ -80,8 +80,8 @@ export interface TypographyProps extends SpaceProps, React.HTMLAttributes<any> {
     weight?: FontWeights;
     color?: 'inherit' | 'initial' | string;
     scale?: Scale;
-    size?: number;
-    lineHeight?: number;
+    size?: number | string;
+    lineHeight?: number | string;
 }
 
 const StyledTypography = (tag: TypographyTags) => styled(tag)<TypographyProps>`

--- a/src/Typography/Typography.stories.tsx
+++ b/src/Typography/Typography.stories.tsx
@@ -109,11 +109,9 @@ storiesOf('Components/Typography', module)
     ))
     .add('Knobus Propus', () => {
         const content = text(
-            'text',
+            'content',
             'The quick brown fox jumps over the lazy dog.'
         );
-        const size = text('size', '');
-        const lineHeight = text('lineHeight', '');
 
         return (
             <ThemeProvider theme={RootTheme}>
@@ -122,10 +120,8 @@ storiesOf('Components/Typography', module)
                         tag={select('tag', Tags, '') || undefined}
                         scale={select('scale', Scales, '') || undefined}
                         color={text('color', '') || undefined}
-                        size={size ? parseFloat(size) : undefined}
-                        lineHeight={
-                            lineHeight ? parseFloat(lineHeight) : undefined
-                        }
+                        size={text('size', '') || undefined}
+                        lineHeight={text('lineHeight', '') || undefined}
                         align={select('align', Alignments, '') || undefined}
                         weight={select('weight', Weights, '') || undefined}
                         transform={

--- a/src/Typography/Typography.stories.tsx
+++ b/src/Typography/Typography.stories.tsx
@@ -2,36 +2,75 @@
 import * as React from 'react';
 // STORYBOOK
 import { storiesOf } from '@storybook/react';
+import { text, select } from '@storybook/addon-knobs';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
-// COMPONENTS
-import { Typography } from './Typography.component';
-// README
+// ANCHOR
+import {
+    Typography,
+    TextAlign,
+    FontWeights,
+    TextTransforms,
+} from './Typography.component';
 import * as README from './README.md';
-// THEME
 import { RootTheme } from '../theme';
+import { typography, TypographyTags, Scale } from '../theme/typography.theme';
 
 const StyledStory = styled('div')`
     padding: 2rem 5rem;
+    font-family: base;
+    color: text.body;
 `;
 
 const scales = [62, 52, 44, 36, 32, 28, 24, 20, 18, 16, 14, 12];
-
-const elements = [
-    'p',
-    'span',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'blockquote',
-    'address',
-    'code',
-    'pre',
-    'a',
+const alignments = [
+    'center',
+    'left',
+    'right',
+    'inherit',
+    'justify',
+    'start',
+    'end',
 ];
+const weights = [
+    'normal',
+    'bold',
+    'bolder',
+    'lighter',
+    100,
+    200,
+    300,
+    400,
+    500,
+    600,
+    700,
+    800,
+    900,
+    'initial',
+    'inherit',
+];
+const transforms = [
+    'none',
+    'capitalize',
+    'uppercase',
+    'lowercase',
+    'initial',
+    'inherit',
+] as TextTransforms[];
+const tags = Object.keys(typography.tag) as TypographyTags[];
+
+type TagSelect = TypographyTags | '';
+type ScaleSelect = Scale | '';
+type AlignSelect = TextAlign | '';
+type WeightSelect = FontWeights | '';
+type TransformsSelect = TextTransforms | '';
+const Tags = [''].concat(tags) as TagSelect[];
+const Scales = ['']
+    .concat(Object.keys(typography.scale))
+    .map(x => parseInt(x, 10) || '') as ScaleSelect[];
+const Alignments = [''].concat(alignments) as AlignSelect[];
+const Weights = weights.concat('') as WeightSelect[];
+const Transforms = [''].concat(transforms) as TransformsSelect[];
 
 storiesOf('Components/Typography', module)
     .addParameters({
@@ -46,7 +85,10 @@ storiesOf('Components/Typography', module)
                 <div>
                     {scales.map((scale: any) => (
                         <div key={scale}>
-                            <Typography color="charcoal" scale={scale}>
+                            <Typography
+                                color="neutrals.charcoal.base"
+                                scale={scale}
+                            >
                                 Font size is {scale}px | Scale value = {scale}
                             </Typography>
                         </div>
@@ -54,7 +96,7 @@ storiesOf('Components/Typography', module)
                 </div>
                 <Typography tag="h1">Elements</Typography>
                 <div>
-                    {elements.map((element: any) => (
+                    {tags.map((element: any) => (
                         <div key={element}>
                             <Typography tag={element}>
                                 Element: {element}
@@ -64,4 +106,35 @@ storiesOf('Components/Typography', module)
                 </div>
             </StyledStory>
         </ThemeProvider>
-    ));
+    ))
+    .add('Knobus Propus', () => {
+        const content = text(
+            'text',
+            'The quick brown fox jumps over the lazy dog.'
+        );
+        const size = text('size', '');
+        const lineHeight = text('lineHeight', '');
+
+        return (
+            <ThemeProvider theme={RootTheme}>
+                <StyledStory>
+                    <Typography
+                        tag={select('tag', Tags, '') || undefined}
+                        scale={select('scale', Scales, '') || undefined}
+                        color={text('color', '') || undefined}
+                        size={size ? parseFloat(size) : undefined}
+                        lineHeight={
+                            lineHeight ? parseFloat(lineHeight) : undefined
+                        }
+                        align={select('align', Alignments, '') || undefined}
+                        weight={select('weight', Weights, '') || undefined}
+                        transform={
+                            select('transform', Transforms, '') || undefined
+                        }
+                    >
+                        {content}
+                    </Typography>
+                </StyledStory>
+            </ThemeProvider>
+        );
+    });

--- a/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
+++ b/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
@@ -4,6 +4,7 @@ exports[`Component: Typography match its snapshot 1`] = `
 .c0 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;
@@ -26,6 +27,7 @@ exports[`Component: Typography should accept a custom display 1`] = `
 .c0 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;
@@ -50,6 +52,7 @@ exports[`Component: Typography should accept a custom lineHeight 1`] = `
 .c0 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;
@@ -73,6 +76,7 @@ exports[`Component: Typography should accept a custom size 1`] = `
 .c0 {
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  margin: 0;
   font-size: 16px;
   line-height: 1.5rem;
   font-weight: normal;

--- a/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
+++ b/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
@@ -9,9 +9,9 @@ exports[`Component: Typography match its snapshot 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
-  color: inherit;
 }
 
 .c0 small {
@@ -34,10 +34,10 @@ exports[`Component: Typography should accept a custom display 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   display: block;
   text-transform: none;
-  color: inherit;
 }
 
 .c0 small {
@@ -61,10 +61,10 @@ exports[`Component: Typography should accept a custom lineHeight 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   line-height: 3rem;
-  color: inherit;
 }
 
 .c0 small {
@@ -87,10 +87,10 @@ exports[`Component: Typography should accept a custom size 1`] = `
   line-height: 1.5rem;
   font-size: 1rem;
   line-height: 1.5rem;
+  color: inherit;
   text-align: inherit;
   text-transform: none;
   font-size: 2rem;
-  color: inherit;
 }
 
 .c0 small {

--- a/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
+++ b/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
@@ -5,13 +5,10 @@ exports[`Component: Typography match its snapshot 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
 }
 
 .c0 small {
@@ -30,14 +27,11 @@ exports[`Component: Typography should accept a custom display 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: inherit;
   text-align: inherit;
+  color: inherit;
   display: block;
-  text-transform: none;
 }
 
 .c0 small {
@@ -57,13 +51,10 @@ exports[`Component: Typography should accept a custom lineHeight 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
   line-height: 3rem;
 }
 
@@ -83,13 +74,10 @@ exports[`Component: Typography should accept a custom size 1`] = `
   box-sizing: border-box;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
   font-size: 16px;
+  line-height: 1.5rem;
   font-weight: normal;
-  line-height: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  color: inherit;
   text-align: inherit;
-  text-transform: none;
+  color: inherit;
   font-size: 2rem;
 }
 

--- a/src/theme/GlobalStyles/Globals.styles.ts
+++ b/src/theme/GlobalStyles/Globals.styles.ts
@@ -5,7 +5,7 @@ import { th } from '@xstyled/system';
 export const GlobalCSS = createGlobalStyle`
   html,
   body {
-    font-family: ${th('typography.fontFamily')};
+    font-family: base;
     color: text.body;
     font-size: ${th('typography.fontSize')};
     letter-spacing: 0;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -2,7 +2,7 @@
 import { typography } from './typography.theme';
 import { ColorsTheme, colors } from './colors.theme';
 import { ThemeProvider as XstyledThemeProvider } from '@xstyled/styled-components';
-
+import { fonts } from './fonts.theme';
 // TODO: ============================================================ move all of these v consts to a different location
 
 // When re-exporting an interface its type must be explicitly defined
@@ -28,6 +28,9 @@ export const RootTheme = {
     [BUTTON_KEY]: BUTTON_THEME,
     [INPUT_KEY]: INPUT_THEME,
     colors: ColorsTheme,
+    fonts: {
+        base: fonts.fontFamily,
+    },
     breakpoints: {
         xs: 0,
     },

--- a/src/theme/typography.theme.ts
+++ b/src/theme/typography.theme.ts
@@ -1,5 +1,5 @@
 // VENDOR
-import { css, FlattenSimpleInterpolation } from '@xstyled/styled-components';
+import { FlattenSimpleInterpolation } from '@xstyled/styled-components';
 // THEME
 import { colors } from './colors.theme';
 import { fonts } from './fonts.theme';
@@ -30,8 +30,8 @@ export interface TypographyTheme {
     fontWeight: string;
     lineHeight: string;
     // FONT TREATMENTS
-    scale: { [T in Scale]: FlattenSimpleInterpolation };
-    tag: { [K in TypographyTags]: FlattenSimpleInterpolation };
+    scale: { [T in Scale | 'none']: FlattenSimpleInterpolation | {} };
+    tag: { [K in TypographyTags | 'none']: FlattenSimpleInterpolation | {} };
 }
 
 export const typography: TypographyTheme = {
@@ -40,150 +40,151 @@ export const typography: TypographyTheme = {
     fontWeight: 'normal',
     lineHeight: '1.5rem',
     scale: {
-        62: css`
-            font-size: 3.875rem;
-            line-height: 4.5rem;
-        `,
-        52: css`
-            font-size: 3.25rem;
-            line-height: 4rem;
-        `,
-        44: css`
-            font-size: 2.75rem;
-            line-height: 3rem;
-        `,
-        36: css`
-            font-size: 2.25rem;
-            line-height: 2.5rem;
-        `,
-        32: css`
-            font-size: 2rem;
-            line-height: 2.5rem;
-        `,
-        28: css`
-            font-size: 1.75rem;
-            line-height: 2rem;
-        `,
-        24: css`
-            font-size: 1.5rem;
-            line-height: 2rem;
-        `,
-        20: css`
-            font-size: 1.25rem;
-            line-height: 1.5rem;
-        `,
-        18: css`
-            font-size: 1.125rem;
-            line-height: 1.5rem;
-        `,
-        16: css`
-            font-size: 1rem;
-            line-height: 1.5rem;
-        `,
-        14: css`
-            font-size: 0.875rem;
-            line-height: 1.125rem;
-        `,
-        12: css`
-            font-size: 0.75rem;
-            line-height: 1rem;
-            font-weight: 500;
-        `,
+        62: {
+            fontSize: '3.875rem',
+            lineHeight: '4.5rem',
+        },
+        52: {
+            fontSize: '3.25rem',
+            lineHeight: '4rem',
+        },
+        44: {
+            fontSize: '2.75rem',
+            lineHeight: '3rem',
+        },
+        36: {
+            fontSize: '2.25rem',
+            lineHeight: '2.5rem',
+        },
+        32: {
+            fontSize: '2rem',
+            lineHeight: '2.5rem',
+        },
+        28: {
+            fontSize: '1.75rem',
+            lineHeight: '2rem',
+        },
+        24: {
+            fontSize: '1.5rem',
+            lineHeight: '2rem',
+        },
+        20: {
+            fontSize: '1.25rem',
+            lineHeight: '1.5rem',
+        },
+        18: {
+            fontSize: '1.125rem',
+            lineHeight: '1.5rem',
+        },
+        16: {
+            fontSize: '1rem',
+            lineHeight: '1.5rem',
+        },
+        14: {
+            fontSize: '0.875rem',
+            lineHeight: '1.125rem',
+        },
+        12: {
+            fontSize: '0.75rem',
+            lineHeight: '1rem',
+            fontWeight: 500,
+        },
+        none: {},
     },
     tag: {
-        a: css`
-            font-weight: normal;
-            font-size: 1rem;
-            line-height: 1.5rem;
-            text-decoration: none;
-            transition: color 250ms;
-            color: text.link.base;
-            cursor: pointer;
-            &:hover {
-                text-decoration: underline;
-                color: text.link.hover;
-            }
-            &:focus {
-                color: text.link.focus;
-            }
-            &:visited {
-                color: text.link.visited;
-            }
-        `,
-        p: css`
-            font-weight: normal;
-            font-size: 1rem;
-            line-height: 1.5rem;
-            margin-bottom: 1rem;
-        `,
-        span: css`
+        a: {
+            fontWeight: 'normal',
+            fontSize: '1rem',
+            lineHeight: '1.5rem',
+            textDecoration: 'none',
+            transition: 'color 250ms',
+            color: 'text.link.base',
+            cursor: 'pointer',
+            '&:hover': {
+                textDecoration: 'underline',
+                color: 'text.link.hover',
+            },
+            '&:focus': {
+                color: 'text.link.focus',
+            },
+            '&:visited': {
+                color: 'text.link.visited',
+            },
+        },
+        p: {
+            fontWeight: 'normal',
+            fontSize: '1rem',
+            lineHeight: '1.5rem',
+            marginBottom: '1rem',
+        },
+        span: {
             // TODO
-        `,
-        h1: css`
-            font-weight: normal;
-            font-size: 1.75rem;
-            line-height: 2rem;
-            margin: 1rem 0;
-        `,
-        h2: css`
-            margin: 1rem 0;
-            font-weight: normal;
-            font-size: 1.5rem;
-            line-height: 2rem;
-        `,
-        h3: css`
-            font-weight: normal;
-            font-size: 1.25rem;
-            line-height: 1.5rem;
-        `,
-        h4: css`
-            font-weight: normal;
-            font-size: 1.125rem;
-            line-height: 1.5rem;
-        `,
-        h5: css`
-            font-weight: normal;
-            font-size: 1rem;
-            line-height: 1.5rem;
-        `,
-        h6: css`
-            font-weight: normal;
-            font-size: 0.875rem;
-            line-height: 1.125rem;
-        `,
-        blockquote: css`
-            margin: 1rem 0;
-            padding: 0.5rem 0 0.5rem 1rem;
-            border-left: 0.5rem solid ${colors.ash.base};
-            color: ${colors.charcoal.base};
-            font-style: italic;
-            line-height: 1.5rem;
-        `,
-        address: css`
-            margin: 0;
-            padding: 0;
-        `,
-        code: css`
-            font-family: SFMono-Regular, Menlo, Monaco, Consolas,
-                'Liberation Mono', 'Courier New', monospace;
-            background: ${colors.charcoal.base};
-            display: block;
-            padding: 1rem;
-            border-radius: 0.25rem;
-            margin: 2rem 0;
-            color: ${colors.white.base};
-            font-size: 0.875rem;
-        `,
-        pre: css`
-            font-family: SFMono-Regular, Menlo, Monaco, Consolas,
-                'Liberation Mono', 'Courier New', monospace;
-        `,
-        label: css`
-            font-weight: normal;
-            line-height: 1.5rem;
-        `,
-        strong: css`
-            font-weight: bold;
-        `,
+        },
+        h1: {
+            fontWeight: 'normal',
+            fontSize: '1.75rem',
+            lineHeight: '2rem',
+            margin: '1rem 0',
+        },
+        h2: {
+            margin: '1rem 0',
+            fontWeight: 'normal',
+            fontSize: '1.5rem',
+            lineHeight: '2rem',
+        },
+        h3: {
+            fontWeight: 'normal',
+            fontSize: '1.25rem',
+            lineHeight: '1.5rem',
+        },
+        h4: {
+            fontWeight: 'normal',
+            fontSize: '1.125rem',
+            lineHeight: '1.5rem',
+        },
+        h5: {
+            fontWeight: 'normal',
+            fontSize: '1rem',
+            lineHeight: '1.5rem',
+        },
+        h6: {
+            fontWeight: 'normal',
+            fontSize: '0.875rem',
+            lineHeight: '1.125rem',
+        },
+        blockquote: {
+            margin: '1rem 0',
+            padding: '0.5rem 0 0.5rem 1rem',
+            borderLeft: 'light',
+            borderLeftWidth: '0.25rem',
+            color: `${colors.charcoal.base}`,
+            fontStyle: 'italic',
+            lineHeight: '1.5rem',
+        },
+        address: {
+            margin: 0,
+            padding: 0,
+        },
+        code: {
+            fontFamily: `SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`,
+            background: `${colors.charcoal.base}`,
+            display: 'block',
+            padding: '1rem',
+            borderRadius: 'base',
+            margin: '2rem 0',
+            color: `${colors.white.base}`,
+            fontSize: '0.875rem',
+        },
+        pre: {
+            fontFamily: `SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`,
+        },
+        label: {
+            fontWeight: 'normal',
+            lineHeight: '1.5rem',
+        },
+        strong: {
+            fontWeight: 'bold',
+        },
+        none: {},
     },
 };

--- a/src/theme/typography.theme.ts
+++ b/src/theme/typography.theme.ts
@@ -93,7 +93,6 @@ export const typography: TypographyTheme = {
     },
     tag: {
         a: {
-            fontWeight: 'normal',
             fontSize: '1rem',
             lineHeight: '1.5rem',
             textDecoration: 'none',
@@ -112,43 +111,33 @@ export const typography: TypographyTheme = {
             },
         },
         p: {
-            fontWeight: 'normal',
             fontSize: '1rem',
             lineHeight: '1.5rem',
-            marginBottom: '1rem',
         },
         span: {
             // TODO
         },
         h1: {
-            fontWeight: 'normal',
             fontSize: '1.75rem',
             lineHeight: '2rem',
-            margin: '1rem 0',
         },
         h2: {
-            margin: '1rem 0',
-            fontWeight: 'normal',
             fontSize: '1.5rem',
             lineHeight: '2rem',
         },
         h3: {
-            fontWeight: 'normal',
             fontSize: '1.25rem',
             lineHeight: '1.5rem',
         },
         h4: {
-            fontWeight: 'normal',
             fontSize: '1.125rem',
             lineHeight: '1.5rem',
         },
         h5: {
-            fontWeight: 'normal',
             fontSize: '1rem',
             lineHeight: '1.5rem',
         },
         h6: {
-            fontWeight: 'normal',
             fontSize: '0.875rem',
             lineHeight: '1.125rem',
         },
@@ -179,7 +168,6 @@ export const typography: TypographyTheme = {
             fontFamily: `SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`,
         },
         label: {
-            fontWeight: 'normal',
             lineHeight: '1.5rem',
         },
         strong: {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -38,7 +38,7 @@ declare module '@xstyled/system' {
         prop,
     }: {
         key?: string;
-        default: string | number;
+        default?: string | number;
         variants?: {
             [key: string]: T;
             [key: number]: T;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Makes `scale` take precedence over `tag` (so that they can be used usefully together)
Removes most redundant styles
Removes typography margins
Removes hue prop