### PR TITLE
fix(Button): only show focus state on tab

### DIFF
--- a/docs/src/pages/components/button.mdx
+++ b/docs/src/pages/components/button.mdx
@@ -30,7 +30,6 @@ below. Also included is an example of an icon button*
         onClick={() => setState(({ size }) => ({
           size: size === 'sm' ? 'md' : 'sm'
         }))}
-        outline={true}
         prefix={<AddEvent />}
         reverse={false}
         size={state.size}
@@ -187,14 +186,6 @@ below. Also included is an example of an icon button*
         property: 'onClick',
         description: `The function to execute when the button is clicked.`,
         type: '() => void',
-    },
-    {
-        property: 'outline',
-        description: `If set to true, outlines the <pre>Button</pre>. Note that depending on the
-            <pre>variant</pre> and <pre>colorTheme</pre> settings this may not appear to do
-            anything.`,
-        type: 'boolean',
-        default: 'true',
     },
     {
         property: 'prefix',

--- a/src/Button/Button.component.tsx
+++ b/src/Button/Button.component.tsx
@@ -36,7 +36,6 @@ export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
     block?: boolean;
     circular?: boolean;
     reverse?: boolean;
-    outline?: boolean;
 
     prefix?: any;
     suffix?: any;
@@ -200,17 +199,11 @@ export const BUTTON_THEME = {
         },
         outline: {
             base: ({ reverse, colorTheme }: StyledButtonProps) =>
-                reverse
-                    ? css`
-                          border: solid thin ${colorTheme.base};
-                          background-color: transparent;
-                          color: ${colorTheme.base};
-                      `
-                    : css`
-                          border: solid thin ${colorTheme.base};
-                          background-color: transparent;
-                          color: ${colorTheme.base};
-                      `,
+                css`
+                    border: solid thin ${colorTheme.base};
+                    background-color: transparent;
+                    color: ${colorTheme.base};
+                `,
             disabled: ({ reverse, colorTheme }: StyledButtonProps) =>
                 reverse
                     ? css`
@@ -249,17 +242,11 @@ export const BUTTON_THEME = {
         },
         minimal: {
             base: ({ reverse, colorTheme }: StyledButtonProps) =>
-                reverse
-                    ? css`
-                          border: solid thin transparent;
-                          background-color: transparent;
-                          color: ${colorTheme.base};
-                      `
-                    : css`
-                          border: solid thin transparent;
-                          background-color: transparent;
-                          color: ${colorTheme.base};
-                      `,
+                css`
+                    border: solid thin transparent;
+                    background-color: transparent;
+                    color: ${colorTheme.base};
+                `,
             disabled: ({ reverse, colorTheme }: StyledButtonProps) =>
                 reverse
                     ? css`
@@ -337,12 +324,7 @@ const stateStyles = createVariant({
     variants: BUTTON_THEME.variants,
 });
 
-const OutlineStyles = ({
-    buttonStyles,
-    borderRadius,
-    outline,
-}: StyledButtonProps) =>
-    outline &&
+const OutlineStyles = ({ buttonStyles, borderRadius }: StyledButtonProps) =>
     css`
         &:after {
             position: absolute;
@@ -362,7 +344,6 @@ const OutlineStyles = ({
         }
     `;
 
-// TODO: grep styled. to styled('')
 const StyledButton = styled('button')<StyledButtonProps>`
     position: relative;
     ${({ borderRadius }) => css`
@@ -491,7 +472,6 @@ export const Button = ({
     flip = false,
     variant = 'filled',
     size = 'md',
-    outline = true,
     block,
     disabled,
     revealed,
@@ -502,8 +482,13 @@ export const Button = ({
     minWidth,
     prefix,
     suffix,
+    onMouseDown,
+    onMouseUp,
+    onFocus,
     ...props
 }: ButtonProps): React.ReactElement<ButtonProps> => {
+    const [mouseDown, setMouseDown] = React.useState(false);
+
     // if there are no children and only prefix or only suffix are set
     const iconOnly =
         (prefix ? !suffix : !!suffix) && React.Children.count(children) === 0;
@@ -567,10 +552,33 @@ export const Button = ({
 
     return (
         <StyledButton
+            onMouseDown={event => {
+                setMouseDown(true);
+                if (onMouseDown) {
+                    onMouseDown(event);
+                }
+            }}
+            onMouseUp={event => {
+                setMouseDown(false);
+                if (onMouseUp) {
+                    onMouseUp(event);
+                }
+            }}
+            onFocus={event => {
+                if (mouseDown) {
+                    // This keeps the button from being :focused when
+                    // clicked so that it is only applied when tabbed to.
+                    // We want the outline to appear when tabbing for
+                    // accessibility.
+                    event.target.blur();
+                }
+                if (onFocus) {
+                    onFocus(event);
+                }
+            }}
             className={classNames('anchor-button', className)}
             flip={flip}
             block={block}
-            outline={outline}
             colorTheme={colorTheme}
             $fontSize={fontSize}
             padding={padding}

--- a/src/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/Button/__snapshots__/Button.spec.tsx.snap
@@ -202,6 +202,9 @@ exports[`Component: Button Icon Only should render a circular icon 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   <span
     className="c2 anchor-icon star anchor-button-prefix"
@@ -429,6 +432,9 @@ exports[`Component: Button Icon Only should render icon-only using a prefix 1`] 
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   <span
     className="c2 anchor-icon star anchor-button-prefix"
@@ -656,6 +662,9 @@ exports[`Component: Button Icon Only should render icon-only using a suffix 1`] 
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   <span
     className="c2 anchor-icon star anchor-button-suffix"
@@ -855,6 +864,9 @@ exports[`Component: Button Reverse Variant: Minimal should be disableable 1`] = 
 <button
   className="c0 c1 anchor-button"
   disabled={true}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -1023,6 +1035,9 @@ exports[`Component: Button Reverse Variant: Minimal should render an minimal but
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -1206,6 +1221,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -1386,6 +1404,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -1576,6 +1597,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -1733,6 +1757,9 @@ exports[`Component: Button Reverse Variant: Outline should be disableable 1`] = 
 <button
   className="c0 c1 anchor-button"
   disabled={true}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -1882,6 +1909,9 @@ exports[`Component: Button Reverse Variant: Outline should render an outline but
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -2043,6 +2073,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -2200,6 +2233,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -2368,6 +2404,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -2509,6 +2548,9 @@ exports[`Component: Button Reverse Variant: Primary should have a disabled state
 <button
   className="c0 c1 anchor-button"
   disabled={true}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -2648,6 +2690,9 @@ exports[`Component: Button Reverse Variant: Primary should render a filled butto
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -2803,6 +2848,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -2956,6 +3004,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -3120,6 +3171,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -3305,6 +3359,9 @@ exports[`Component: Button Sizes should render a md button 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -3489,6 +3546,9 @@ exports[`Component: Button Sizes should render an lg button 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -3686,6 +3746,9 @@ exports[`Component: Button Sizes should render an sm button 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   <div
     className="c2"
@@ -3890,6 +3953,9 @@ exports[`Component: Button Sizes should render an xs button 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   <div
     className="c2"
@@ -4097,6 +4163,9 @@ exports[`Component: Button Theme Provided should use custom size variants from t
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 />
 `;
 
@@ -4214,6 +4283,9 @@ exports[`Component: Button Variant: Minimal should be disableable 1`] = `
 <button
   className="c0 c1 anchor-button"
   disabled={true}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -4326,6 +4398,9 @@ exports[`Component: Button Variant: Minimal should render an minimal button 1`] 
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -4449,6 +4524,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -4568,6 +4646,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -4698,6 +4779,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -4802,6 +4886,9 @@ exports[`Component: Button Variant: Outline should be disableable 1`] = `
 <button
   className="c0 c1 anchor-button"
   disabled={true}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -4899,6 +4986,9 @@ exports[`Component: Button Variant: Outline should render an outline button 1`] 
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -5008,6 +5098,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -5113,6 +5206,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -5229,6 +5325,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -5322,6 +5421,9 @@ exports[`Component: Button Variant: Primary should accept a color theme 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -5389,6 +5491,9 @@ exports[`Component: Button Variant: Primary should have a disabled state 1`] = `
 <button
   className="c0 c1 anchor-button"
   disabled={true}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -5466,6 +5571,9 @@ exports[`Component: Button Variant: Primary should have a revealed state when fl
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -5534,6 +5642,9 @@ exports[`Component: Button Variant: Primary should render a filled button 1`] = 
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
 </button>
@@ -5625,6 +5736,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -5712,6 +5826,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -5810,6 +5927,9 @@ Array [
 
 <button
     className="c0 c1 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     Text
   </button>,
@@ -5921,6 +6041,9 @@ exports[`Component: Button Variant: Primary should render properly when flipped 
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
   <div
@@ -6023,6 +6146,9 @@ exports[`Component: Button Variant: Primary should render with a prefix 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   <span
     className="c2 anchor-icon star anchor-button-prefix"
@@ -6144,6 +6270,9 @@ exports[`Component: Button Variant: Primary should render with a suffix 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Text
   <span
@@ -6237,6 +6366,9 @@ exports[`Component: Button should be defined 1`] = `
 
 <button
   className="c0 c1 anchor-button"
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
 >
   Submit
 </button>

--- a/src/Hero/__snapshots__/Hero.spec.tsx.snap
+++ b/src/Hero/__snapshots__/Hero.spec.tsx.snap
@@ -161,6 +161,9 @@ exports[`Component: Hero should render with custom content 1`] = `
   </span>
   <button
     className="c4 c5 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     CTA
   </button>

--- a/src/Modal/Close/Close.component.tsx
+++ b/src/Modal/Close/Close.component.tsx
@@ -38,12 +38,6 @@ export const ModalClose = ({
         className={classnames('anchor-modal-close', className)}
         align={align}
     >
-        <Button
-            prefix={<Close />}
-            variant="minimal"
-            circular
-            outline={false}
-            {...props}
-        />
+        <Button prefix={<Close />} variant="minimal" circular {...props} />
     </StyledClose>
 );

--- a/src/Modal/Close/__snapshots__/Close.spec.tsx.snap
+++ b/src/Modal/Close/__snapshots__/Close.spec.tsx.snap
@@ -46,6 +46,17 @@ exports[`Component: Modal.Close should match snapshot with alignment set 1`] = `
   color: #0074A6;
 }
 
+.c2:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(circular + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c3 {
   display: inline-block;
   height: 1.5rem;
@@ -80,6 +91,9 @@ exports[`Component: Modal.Close should match snapshot with alignment set 1`] = `
 >
   <button
     className="c1 c2 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <span
       className="c3 anchor-icon close anchor-button-prefix"
@@ -162,6 +176,17 @@ exports[`Component: Modal.Close should render 1`] = `
   color: #0074A6;
 }
 
+.c2:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(circular + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c3 {
   display: inline-block;
   height: 1.5rem;
@@ -196,6 +221,9 @@ exports[`Component: Modal.Close should render 1`] = `
 >
   <button
     className="c1 c2 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <span
       className="c3 anchor-icon close anchor-button-prefix"

--- a/src/Pagination/Pagination.component.tsx
+++ b/src/Pagination/Pagination.component.tsx
@@ -22,11 +22,8 @@ const constrain = (min: number, value: number, max: number) =>
 const Button = ({
     variant = 'minimal',
     size = 'sm',
-    outline = false,
     ...props
-}: ButtonProps) => (
-    <AnchorButton variant={variant} size={size} outline={outline} {...props} />
-);
+}: ButtonProps) => <AnchorButton variant={variant} size={size} {...props} />;
 
 export type Size = 'sm' | 'xs';
 export type Variant = 'expanded' | 'minimal';

--- a/src/Pagination/__snapshots__/Pagination.spec.tsx.snap
+++ b/src/Pagination/__snapshots__/Pagination.spec.tsx.snap
@@ -49,6 +49,17 @@ exports[`Component: Pagination should be defined. 1`] = `
   margin-left: 1rem;
 }
 
+.c2:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c5 {
   position: relative;
   border-radius: 4px;
@@ -92,6 +103,17 @@ exports[`Component: Pagination should be defined. 1`] = `
 .c5:active {
   background-color: #0074A6;
   border: solid thin #0074A6;
+}
+
+.c5:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(9,152,214,0.4);
 }
 
 .c6 {
@@ -139,6 +161,17 @@ exports[`Component: Pagination should be defined. 1`] = `
   color: #0074A6;
 }
 
+.c6:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c4 {
   display: inline-block;
   height: 1.5rem;
@@ -171,6 +204,9 @@ exports[`Component: Pagination should be defined. 1`] = `
     className="c1 c2 anchor-button"
     disabled={true}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -196,6 +232,9 @@ exports[`Component: Pagination should be defined. 1`] = `
   <button
     className="c1 c5 anchor-button active"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -205,6 +244,9 @@ exports[`Component: Pagination should be defined. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -214,6 +256,9 @@ exports[`Component: Pagination should be defined. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -223,6 +268,9 @@ exports[`Component: Pagination should be defined. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -232,6 +280,9 @@ exports[`Component: Pagination should be defined. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -242,6 +293,9 @@ exports[`Component: Pagination should be defined. 1`] = `
     className="c1 c6 anchor-button"
     disabled={false}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -267,11 +321,11 @@ exports[`Component: Pagination should be defined. 1`] = `
 </div>
 `;
 
-exports[`Component: Pagination should behave properly when uncontrolled. 1`] = `"<div class=\\"sc-fgfRvd lalOmR anchor-pagination\\"><button class=\\"sc-emmjRN Zxont anchor-button\\" disabled=\\"\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-left anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M7.522 8l2.518 2.953a.77.77 0 0 1 0 1.058l-.015.015a.721.721 0 0 1-1.052-.01L5.96 8.53a.767.767 0 0 1-.009-1.048l3.03-3.507a.719.719 0 0 1 1.043 0l.016.015c.28.293.28.765.01 1.047L7.522 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button><button class=\\"sc-emmjRN juCONG anchor-button active\\"><div class=\\"sc-eerKOB gUivrk\\"></div>1</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>2</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>3</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>4</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>5</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt cAHrQG anchor-icon ellipses anchor-button-prefix\\" scale=\\"md\\"><svg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"><defs><path d=\\"M3.5 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM8 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\\" id=\\"ellipsis-a\\"></path></defs><g fill=\\"none\\" fill-rule=\\"evenodd\\"><path d=\\"M0 0h16v16H0z\\"></path><use fill=\\"currentColor\\" xlink:href=\\"#ellipsis-a\\"></use></g></svg></span></button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>20</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-right anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M8.478 8L5.96 5.047a.77.77 0 0 1 .001-1.058l.014-.015a.721.721 0 0 1 1.052.01L10.04 7.47c.28.293.28.765.009 1.048l-3.03 3.507a.719.719 0 0 1-1.043 0l-.015-.015a.767.767 0 0 1-.01-1.047L8.477 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button></div>"`;
+exports[`Component: Pagination should behave properly when uncontrolled. 1`] = `"<div class=\\"sc-fgfRvd lalOmR anchor-pagination\\"><button class=\\"sc-emmjRN bQpYWe anchor-button\\" disabled=\\"\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-left anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M7.522 8l2.518 2.953a.77.77 0 0 1 0 1.058l-.015.015a.721.721 0 0 1-1.052-.01L5.96 8.53a.767.767 0 0 1-.009-1.048l3.03-3.507a.719.719 0 0 1 1.043 0l.016.015c.28.293.28.765.01 1.047L7.522 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button><button class=\\"sc-emmjRN bDhhVq anchor-button active\\"><div class=\\"sc-eerKOB gUivrk\\"></div>1</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>2</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>3</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>4</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>5</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt cAHrQG anchor-icon ellipses anchor-button-prefix\\" scale=\\"md\\"><svg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"><defs><path d=\\"M3.5 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM8 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\\" id=\\"ellipsis-a\\"></path></defs><g fill=\\"none\\" fill-rule=\\"evenodd\\"><path d=\\"M0 0h16v16H0z\\"></path><use fill=\\"currentColor\\" xlink:href=\\"#ellipsis-a\\"></use></g></svg></span></button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>20</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-right anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M8.478 8L5.96 5.047a.77.77 0 0 1 .001-1.058l.014-.015a.721.721 0 0 1 1.052.01L10.04 7.47c.28.293.28.765.009 1.048l-3.03 3.507a.719.719 0 0 1-1.043 0l-.015-.015a.767.767 0 0 1-.01-1.047L8.477 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button></div>"`;
 
-exports[`Component: Pagination should behave properly when uncontrolled. 2`] = `"<div class=\\"sc-fgfRvd lalOmR anchor-pagination\\"><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-left anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M7.522 8l2.518 2.953a.77.77 0 0 1 0 1.058l-.015.015a.721.721 0 0 1-1.052-.01L5.96 8.53a.767.767 0 0 1-.009-1.048l3.03-3.507a.719.719 0 0 1 1.043 0l.016.015c.28.293.28.765.01 1.047L7.522 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>1</button><button class=\\"sc-emmjRN juCONG anchor-button active\\"><div class=\\"sc-eerKOB gUivrk\\"></div>2</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>3</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>4</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>5</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt cAHrQG anchor-icon ellipses anchor-button-prefix\\" scale=\\"md\\"><svg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"><defs><path d=\\"M3.5 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM8 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\\" id=\\"ellipsis-a\\"></path></defs><g fill=\\"none\\" fill-rule=\\"evenodd\\"><path d=\\"M0 0h16v16H0z\\"></path><use fill=\\"currentColor\\" xlink:href=\\"#ellipsis-a\\"></use></g></svg></span></button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>20</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-right anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M8.478 8L5.96 5.047a.77.77 0 0 1 .001-1.058l.014-.015a.721.721 0 0 1 1.052.01L10.04 7.47c.28.293.28.765.009 1.048l-3.03 3.507a.719.719 0 0 1-1.043 0l-.015-.015a.767.767 0 0 1-.01-1.047L8.477 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button></div>"`;
+exports[`Component: Pagination should behave properly when uncontrolled. 2`] = `"<div class=\\"sc-fgfRvd lalOmR anchor-pagination\\"><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-left anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M7.522 8l2.518 2.953a.77.77 0 0 1 0 1.058l-.015.015a.721.721 0 0 1-1.052-.01L5.96 8.53a.767.767 0 0 1-.009-1.048l3.03-3.507a.719.719 0 0 1 1.043 0l.016.015c.28.293.28.765.01 1.047L7.522 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>1</button><button class=\\"sc-emmjRN bDhhVq anchor-button active\\"><div class=\\"sc-eerKOB gUivrk\\"></div>2</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>3</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>4</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>5</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt cAHrQG anchor-icon ellipses anchor-button-prefix\\" scale=\\"md\\"><svg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"><defs><path d=\\"M3.5 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM8 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\\" id=\\"ellipsis-a\\"></path></defs><g fill=\\"none\\" fill-rule=\\"evenodd\\"><path d=\\"M0 0h16v16H0z\\"></path><use fill=\\"currentColor\\" xlink:href=\\"#ellipsis-a\\"></use></g></svg></span></button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>20</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-right anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M8.478 8L5.96 5.047a.77.77 0 0 1 .001-1.058l.014-.015a.721.721 0 0 1 1.052.01L10.04 7.47c.28.293.28.765.009 1.048l-3.03 3.507a.719.719 0 0 1-1.043 0l-.015-.015a.767.767 0 0 1-.01-1.047L8.477 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button></div>"`;
 
-exports[`Component: Pagination should behave properly when uncontrolled. 3`] = `"<div class=\\"sc-fgfRvd lalOmR anchor-pagination\\"><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-left anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M7.522 8l2.518 2.953a.77.77 0 0 1 0 1.058l-.015.015a.721.721 0 0 1-1.052-.01L5.96 8.53a.767.767 0 0 1-.009-1.048l3.03-3.507a.719.719 0 0 1 1.043 0l.016.015c.28.293.28.765.01 1.047L7.522 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>1</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt cAHrQG anchor-icon ellipses anchor-button-prefix\\" scale=\\"md\\"><svg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"><defs><path d=\\"M3.5 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM8 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\\" id=\\"ellipsis-a\\"></path></defs><g fill=\\"none\\" fill-rule=\\"evenodd\\"><path d=\\"M0 0h16v16H0z\\"></path><use fill=\\"currentColor\\" xlink:href=\\"#ellipsis-a\\"></use></g></svg></span></button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>16</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>17</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>18</button><button class=\\"sc-emmjRN gRSoVn anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>19</button><button class=\\"sc-emmjRN juCONG anchor-button active\\"><div class=\\"sc-eerKOB gUivrk\\"></div>20</button><button class=\\"sc-emmjRN Zxont anchor-button\\" disabled=\\"\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-right anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M8.478 8L5.96 5.047a.77.77 0 0 1 .001-1.058l.014-.015a.721.721 0 0 1 1.052.01L10.04 7.47c.28.293.28.765.009 1.048l-3.03 3.507a.719.719 0 0 1-1.043 0l-.015-.015a.767.767 0 0 1-.01-1.047L8.477 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button></div>"`;
+exports[`Component: Pagination should behave properly when uncontrolled. 3`] = `"<div class=\\"sc-fgfRvd lalOmR anchor-pagination\\"><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-left anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M7.522 8l2.518 2.953a.77.77 0 0 1 0 1.058l-.015.015a.721.721 0 0 1-1.052-.01L5.96 8.53a.767.767 0 0 1-.009-1.048l3.03-3.507a.719.719 0 0 1 1.043 0l.016.015c.28.293.28.765.01 1.047L7.522 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>1</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt cAHrQG anchor-icon ellipses anchor-button-prefix\\" scale=\\"md\\"><svg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"><defs><path d=\\"M3.5 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM8 10a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\\" id=\\"ellipsis-a\\"></path></defs><g fill=\\"none\\" fill-rule=\\"evenodd\\"><path d=\\"M0 0h16v16H0z\\"></path><use fill=\\"currentColor\\" xlink:href=\\"#ellipsis-a\\"></use></g></svg></span></button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>16</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>17</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>18</button><button class=\\"sc-emmjRN hEmChG anchor-button\\"><div class=\\"sc-eerKOB gUivrk\\"></div>19</button><button class=\\"sc-emmjRN bDhhVq anchor-button active\\"><div class=\\"sc-eerKOB gUivrk\\"></div>20</button><button class=\\"sc-emmjRN bQpYWe anchor-button\\" disabled=\\"\\"><div class=\\"sc-eerKOB gUivrk\\"></div><span class=\\"sc-CtfFt fauNcJ anchor-icon chevron-right anchor-button-prefix\\" scale=\\"lg\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 16 16\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M8.478 8L5.96 5.047a.77.77 0 0 1 .001-1.058l.014-.015a.721.721 0 0 1 1.052.01L10.04 7.47c.28.293.28.765.009 1.048l-3.03 3.507a.719.719 0 0 1-1.043 0l-.015-.015a.767.767 0 0 1-.01-1.047L8.477 8z\\" fill=\\"currentColor\\" fill-rule=\\"nonzero\\"></path></svg></span></button></div>"`;
 
 exports[`Component: Pagination should render on the last page. 1`] = `
 .c3 {
@@ -322,6 +376,17 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   margin-left: 1rem;
 }
 
+.c7:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c6 {
   position: relative;
   border-radius: 4px;
@@ -365,6 +430,17 @@ exports[`Component: Pagination should render on the last page. 1`] = `
 .c6:active {
   background-color: #0074A6;
   border: solid thin #0074A6;
+}
+
+.c6:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(9,152,214,0.4);
 }
 
 .c2 {
@@ -412,6 +488,17 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   color: #0074A6;
 }
 
+.c2:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c4 {
   display: inline-block;
   height: 1.5rem;
@@ -451,6 +538,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
     className="c1 c2 anchor-button"
     disabled={false}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -476,6 +566,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -484,6 +577,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   </button>
   <button
     className="c1 c2 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -523,6 +619,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -532,6 +631,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -541,6 +643,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -550,6 +655,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -559,6 +667,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
   <button
     className="c1 c6 anchor-button active"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -569,6 +680,9 @@ exports[`Component: Pagination should render on the last page. 1`] = `
     className="c1 c7 anchor-button"
     disabled={true}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -653,6 +767,17 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   border: solid thin #0074A6;
 }
 
+.c6:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(9,152,214,0.4);
+}
+
 .c2 {
   position: relative;
   border-radius: 4px;
@@ -698,6 +823,17 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   color: #0074A6;
 }
 
+.c2:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c4 {
   display: inline-block;
   height: 1.5rem;
@@ -737,6 +873,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
     className="c1 c2 anchor-button"
     disabled={false}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -762,6 +901,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -770,6 +912,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   </button>
   <button
     className="c1 c2 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -809,6 +954,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -818,6 +966,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   <button
     className="c1 c6 anchor-button active"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -827,6 +978,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -835,6 +989,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   </button>
   <button
     className="c1 c2 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -874,6 +1031,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
   <button
     className="c1 c2 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -884,6 +1044,9 @@ exports[`Component: Pagination should render with current page in the middle. 1`
     className="c1 c2 anchor-button"
     disabled={false}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -958,6 +1121,17 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   margin-left: 1rem;
 }
 
+.c2:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c5 {
   position: relative;
   border-radius: 4px;
@@ -1001,6 +1175,17 @@ exports[`Component: Pagination should render with many pages. 1`] = `
 .c5:active {
   background-color: #0074A6;
   border: solid thin #0074A6;
+}
+
+.c5:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(9,152,214,0.4);
 }
 
 .c6 {
@@ -1048,6 +1233,17 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   color: #0074A6;
 }
 
+.c6:focus:after {
+  position: absolute;
+  content: '';
+  top: calc(-1px - 2px);
+  left: calc(-1px - 2px);
+  right: calc(-1px - 2px);
+  bottom: calc(-1px - 2px);
+  border-radius: calc(4px + 2px);
+  box-shadow: 0 0 0 2px rgba(128,128,128,0.4);
+}
+
 .c4 {
   display: inline-block;
   height: 1.5rem;
@@ -1087,6 +1283,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
     className="c1 c2 anchor-button"
     disabled={true}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1112,6 +1311,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   <button
     className="c1 c5 anchor-button active"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1121,6 +1323,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1130,6 +1335,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1139,6 +1347,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1148,6 +1359,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1156,6 +1370,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   </button>
   <button
     className="c1 c6 anchor-button"
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1195,6 +1412,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
   <button
     className="c1 c6 anchor-button"
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"
@@ -1205,6 +1425,9 @@ exports[`Component: Pagination should render with many pages. 1`] = `
     className="c1 c6 anchor-button"
     disabled={false}
     onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
   >
     <div
       className="c3"

--- a/src/Skeleton/Skeleton.stories.tsx
+++ b/src/Skeleton/Skeleton.stories.tsx
@@ -187,7 +187,6 @@ storiesOf('Components/Skeleton', module)
                                     variant="minimal"
                                     circular
                                     size="sm"
-                                    outline={false}
                                     prefix={<Close />}
                                 />
                             )}


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Makes the outline only appear when the button is tabbed to.