### PR TITLE
docs: Update Card and DropDown to use Anchor components in examples

### DIFF
--- a/docs/src/components/CardExample/MoreInfo.component.tsx
+++ b/docs/src/components/CardExample/MoreInfo.component.tsx
@@ -5,31 +5,21 @@
  */
 
 import * as React from 'react';
-import styled from 'styled-components';
-import { colors, InfoOutline } from '@retailmenot/anchor';
+import styled from '@xstyled/styled-components';
+import { colors, DropDown, InfoOutline } from '@retailmenot/anchor';
 
-const StyledMoreInfo = styled(InfoOutline)`
-    position: relative;
-
-    &:hover {
-        cursor: pointer;
-
-        &:after {
-            content: 'I am an Action';
-            display: block;
-            padding: 1rem;
-            background-color: ${colors.success.dark};
-            color: ${colors.white.base};
-            position: absolute;
-            right: 1.75rem;
-            white-space: nowrap;
-            top: 0;
-            z-index: 1000;
-            border-radius: 0.25rem;
-        }
-    }
+const StyledMessage = styled('div')`
+    color: ${colors.white.base};
+    padding: 0.5rem 1rem;
 `;
 
 export const MoreInfo = () => (
-    <StyledMoreInfo color={colors.success.dark} scale="lg" />
+    <DropDown
+        overlay={<StyledMessage>I am an 'action'.</StyledMessage>}
+        trigger="both"
+        position="leftStart"
+        background={colors.grapePurchase.light}
+    >
+        <InfoOutline scale="lg" color={colors.grapePurchase.light} />
+    </DropDown>
 );

--- a/docs/src/components/DropDownExample/MyList.component.tsx
+++ b/docs/src/components/DropDownExample/MyList.component.tsx
@@ -5,31 +5,14 @@
  */
 
 import * as React from 'react';
-import styled from '@xstyled/styled-components';
-import { colors } from '@retailmenot/anchor';
-
-const StyledMyList = styled('ul')`
-    width: 100%;
-    display: block;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-
-    li {
-        margin: 0;
-        padding: 0.5rem 2rem;
-        border-bottom: solid ${colors.savvyCyan.base} 1px;
-
-        &:last-child {
-            border-bottom-style: none;
-        }
-    }
-`;
+import { List, ListDivider, ListItem, ListTitle } from '@retailmenot/anchor';
 
 export const MyList = () => (
-    <StyledMyList>
-        <li>Not Actually A Link,</li>
-        <li>But An Example of Possibilities,</li>
-        <li>Because Anything Could be Here...</li>
-    </StyledMyList>
+    <List>
+        <ListTitle>I Am a Title</ListTitle>
+        <ListItem>I Am Item #1</ListItem>
+        <ListItem>I Am Item #2</ListItem>
+        <ListDivider />
+        <ListItem>I Am Item #3</ListItem>
+    </List>
 );

--- a/docs/src/pages/components/card.mdx
+++ b/docs/src/pages/components/card.mdx
@@ -19,46 +19,45 @@ import {
 ## Putting it Together
 
 `Card` is used to organize content in a concise way so it's a good idea to to create a few
-components ahead of time to use. In the example below, we have a styled component that is extending
-**Anchor**'s `InfoOutline` component, one of the <Link to="/components/icon/">icons</Link>. Hovering
-over the icon will display a small tooltip. Note that we're importing **Anchor**'s `colors`
-object for all of the examples to follow. Refer to the <Link to="/theme/colors">colors</Link> section for
-more information.
+components ahead of time to use. In the example below, we have a component utilizing two **Anchor**
+components, <Link to="/components/dropdown">DropDown</Link> and `InfoOutline`, one of
+the <Link to="/components/icon/">icons</Link>. Clicking on or hovering over the icon will display a
+small message. Note that we're importing **Anchor**'s `colors` object for all of the examples to
+follow. Refer to the <Link to="/theme/colors">colors</Link> section for more information.
 
 ###### MoreInfo Component Example
 ```jsx hideTitle
 import * as React from 'react';
-import styled from 'styled-components';
-import { colors, InfoOutline } from '@retailmenot/anchor';
+import styled from '@xstyled/styled-components';
+import {
+    colors,
+    DropDown,
+    InfoOutline
+} from '@retailmenot/anchor';
 
-const StyledMoreInfo = styled(InfoOutline)`
-    position:relative;
-
-    &:hover {
-        cursor:pointer;
-
-        &:after {
-            content: 'I am an Action';
-            display: block;
-            padding: 1rem;
-            background-color: ${colors.success.dark};
-            color: ${colors.white.base};
-            position: absolute;
-            right: 1.75rem;
-            white-space: nowrap;
-            top: 0;
-            z-index: 1000;
-            border-radius: 0.25rem;
-        }
-    }
+const StyledMessage = styled('div')`
+    color: ${colors.white.base};
+    padding: 0.5rem 1rem;
 `;
 
 export const MoreInfo = () => (
-    <StyledMoreInfo
-        color={colors.success.dark}
-        scale="lg"
-    />
+    <DropDown
+        overlay={(
+            <StyledMessage>
+                I am an 'action'.
+            </StyledMessage>
+        )}
+        trigger="both"
+        position="leftStart"
+        background={colors.grapePurchase.light}
+    >
+        <InfoOutline
+            scale="lg"
+            color={colors.grapePurchase.light}
+        />
+    </DropDown>
 );
+
 ```
 
 Next, we're going to build a component that will display a short message with a background color.

--- a/docs/src/pages/components/dropdown.mdx
+++ b/docs/src/pages/components/dropdown.mdx
@@ -49,39 +49,36 @@ export const MouseOverMe = styled(Typography)`
 `;
 ```
 
-Next, lets make the content for the `overlay`. This will be an unordered list with a little bit of
-styling.
+Next, lets make the content for the `overlay`. This is made
+using <Link to="/components/list">`List`</Link> and its subcomponents, `ListDivider`, `ListItem` and
+`ListTitle`.
 
 ###### MyList Component
 ```jsx hideTitle
 import * as React from 'react';
-import styled from '@xstyled/styled-components';
-import { colors} from '@retailmenot/anchor';
-
-const StyledMyList = styled('ul')`
-    width:100%;
-    display:block;
-    list-style: none;
-    margin:0;
-    padding:0;
-
-    li {
-        margin:0;
-        padding: 0.5rem 2rem;
-        border-bottom: solid ${ colors.savvyCyan.base } 1px;
-
-        &:last-child {
-            border-bottom-style:none;
-        }
-    }
-`;
+import {
+    List,
+    ListDivider,
+    ListItem,
+    ListTitle
+} from '@retailmenot/anchor';
 
 export const MyList = () => (
-    <StyledMyList>
-        <li>Not Actually A Link,</li>
-        <li>But An Example of Possibilities,</li>
-        <li>Because Anything Could be Here...</li>
-    </StyledMyList>
+    <List>
+        <ListTitle>
+            I Am a Title
+        </ListTitle>
+        <ListItem>
+            I Am Item #1
+        </ListItem>
+        <ListItem>
+            I Am Item #2
+        </ListItem>
+        <ListDivider />
+        <ListItem>
+            I Am Item #3
+        </ListItem>
+    </List>
 );
 ```
 

--- a/docs/src/typings.d.ts
+++ b/docs/src/typings.d.ts
@@ -11,6 +11,7 @@ declare module '@retailmenot/anchor' {
   const AutoComplete: any;
   const Badge: any;
   const Button: any;
+  const Card: any;
   const Cart: any;
   const Check: any;
   const Col: any;
@@ -19,8 +20,12 @@ declare module '@retailmenot/anchor' {
   const colors: any;
   const Container: any;
   const DropDown: any;
+  const InfoOutline: any;
   const Input: any;
+  const List: any;
+  const ListDivider: any;
   const ListItem: any;
+  const ListTitle: any;
   const Modal: any;
   const ModalProvider: any;
   const RootTheme: any;

--- a/docs/src/typings.d.ts
+++ b/docs/src/typings.d.ts
@@ -7,35 +7,6 @@ declare module '@mdx-js/tag' {
 declare module '@reach/component-component' {
   const Component: any;
 }
-declare module '@retailmenot/anchor' {
-  const AutoComplete: any;
-  const Badge: any;
-  const Button: any;
-  const Card: any;
-  const Cart: any;
-  const Check: any;
-  const Col: any;
-  const Collapse: any;
-  const CollapseGroup: any;
-  const colors: any;
-  const Container: any;
-  const DropDown: any;
-  const InfoOutline: any;
-  const Input: any;
-  const List: any;
-  const ListDivider: any;
-  const ListItem: any;
-  const ListTitle: any;
-  const Modal: any;
-  const ModalProvider: any;
-  const RootTheme: any;
-  const Row: any;
-  const Search: any;
-  const sizes: any;
-  const ThemeProvider: any;
-  const Tooltip: any;
-  const Typography: any;
-}
 
 declare module '@xstyled/styled-components' {
     import {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@types/react-test-renderer": "^16.0.3",
     "@types/storybook__addon-actions": "^3.4.3",
     "@types/storybook__addon-info": "^4.1.2",
-    "@types/storybook__addon-knobs": "^5.0.4",
     "@types/storybook__addon-links": "^3.3.5",
     "@types/storybook__addon-options": "^4.0.2",
     "@types/storybook__react": "^4.0.2",


### PR DESCRIPTION
chore(typings): added Card, InfoOutline, List, ListDivider & ListTitle

fix(MoreInfo): using DropDown for its example rather than homebrew

fix(MyList) using List for its example rather than homebrew

docs(card and dropdown): Updated code blocks based on the above changes

chore: prettier

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
