### PR TITLE
fix: add missing global styles

### DIFF
--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -30,6 +30,12 @@ import { breakpoints, BreakpointsType, responsiveCSS } from '../../Utils';
 // ASSETS
 import logo from './anchor-logo.svg';
 
+const GlobalCSS = createGlobalStyle`
+    body {
+        margin: 0;
+    }
+`;
+
 const StyledPageElement = styled('div')`
     // The Row component can't be extended, so targeting it via class
     .anchor-row {
@@ -108,6 +114,8 @@ const StyledSectionNav = styled('div')<StyledSectionNavProps>`
         z-index: 90;
         overflow-y: scroll;
         top: 4.5rem;
+        left: 0;
+        right: 0;
         padding-bottom: 30rem;
     `}
 `;
@@ -183,6 +191,8 @@ export const Page = ({
                 render={(breakpoint: BreakpointsType) => (
                     <StyledPageElement className={classNames(className)}>
                         <Helmet htmlAttributes={{ lang: 'en' }} />
+
+                        <GlobalCSS />
 
                         <StyledHeader>
                             <Container>


### PR DESCRIPTION
fix(Page): added GlobalCSS, body margin to 0px

fix(Page): added left/right at 0 to StyledSectionNav for xs/sm

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

With the removal of Normalize and (I suspect) other changes with spacing in components, the doc site had some margin on the body and and the hamburger navigation did not fill the screen. This fixes those issues.