### PR TITLE
[WIP] feat: responsiveQuery & typings for Grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Grid/Grid/Grid.component.tsx
+++ b/src/Grid/Grid/Grid.component.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 // VENDOR
 import classnames from 'classnames';
+import { ThemeProvider } from '@xstyled/styled-components';
 import {
     Col as ACol,
     Visible as AVisible,
@@ -14,6 +15,23 @@ import {
     VisibleProps,
     ColProps,
 } from 'react-awesome-styled-grid';
+import { StandardBreakpoints } from '../Adaptor/Adaptor.component';
+import { RootTheme } from '../../theme';
+
+const rem = (val: number | undefined): number => (val && typeof val === "number") ? Math.floor(val / 16) : 0;
+
+const GridTheme = {
+    ...RootTheme,
+    awesomegrid: {
+        breakpoints: {
+            xs: 1,
+            sm: rem(StandardBreakpoints.sm.min),
+            md: rem(StandardBreakpoints.md.min),
+            lg: rem(StandardBreakpoints.lg.min),
+            xl: rem(StandardBreakpoints.xl.min),
+        },
+    },
+};
 
 export enum responsiveValues {
     xs = 'xs',
@@ -39,9 +57,13 @@ export const Col = ({
     debug,
     noGutter,
     ...props
-}: ColProps) => (
-    <ACol className={classnames('anchor-col', className)} {...props} />
-);
+}: ColProps) => {
+    return (
+        <ThemeProvider theme={GridTheme}>
+            <ACol className={classnames('anchor-col', className)} {...props} />
+        </ThemeProvider>
+    );
+};
 
 export const Visible = ({
     className,
@@ -53,7 +75,9 @@ export const Visible = ({
     debug,
     ...props
 }: VisibleProps) => (
-    <AVisible className={classnames('anchor-visible', className)} {...props} />
+    <ThemeProvider theme={GridTheme}>
+        <AVisible className={classnames('anchor-visible', className)} {...props} />
+    </ThemeProvider>
 );
 
 export const Row = ({ className, ...props }: any) => (

--- a/src/Grid/Grid/Grid.component.tsx
+++ b/src/Grid/Grid/Grid.component.tsx
@@ -10,35 +10,86 @@ import {
     ScreenClass as AScreenClass,
     ScreenBadge as AScreenBadge,
     Hidden as AHidden,
+    config as aConfig,
+    VisibleProps,
+    ColProps,
 } from 'react-awesome-styled-grid';
 
-export const Col = ({ className, ...props }: any) => (
+export enum responsiveValues {
+    xs = 'xs',
+    sm = 'sm',
+    md = 'md',
+    lg = 'lg',
+    xl = 'xl',
+}
+
+type ResponsiveArrayValues = keyof typeof responsiveValues;
+
+export const responsiveQuery = (
+    props: object,
+    responsiveValue: ResponsiveArrayValues
+) => {
+    return aConfig(props).media[responsiveValue];
+};
+
+export const Col = ({
+    className,
+    offset,
+    reverse,
+    debug,
+    noGutter,
+    ...props
+}: ColProps) => (
     <ACol className={classnames('anchor-col', className)} {...props} />
 );
-export const Visible = ({ className, ...props }: any) => (
+
+export const Visible = ({
+    className,
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+    debug,
+    ...props
+}: VisibleProps) => (
     <AVisible className={classnames('anchor-visible', className)} {...props} />
 );
+
 export const Row = ({ className, ...props }: any) => (
     <ARow className={classnames('anchor-row')} {...props} />
 );
+
 export const Container = ({ className, ...props }: any) => (
     <AContainer
         className={classnames('anchor-container', className)}
         {...props}
     />
 );
+
 export const ScreenClass = ({ className, ...props }: any) => (
     <AScreenClass
         className={classnames('anchor-screen-class', className)}
         {...props}
     />
 );
+
 export const ScreenBadge = ({ className, ...props }: any) => (
     <AScreenBadge
         className={classnames('anchor-screen-badge', className)}
         {...props}
     />
 );
-export const Hidden = ({ className, ...props }: any) => (
+
+export const Hidden = ({
+    className,
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+    debug,
+    ...props
+}: VisibleProps) => (
     <AHidden className={classnames('anchor-hidden', className)} {...props} />
 );

--- a/src/Grid/Grid/Grid.stories.tsx
+++ b/src/Grid/Grid/Grid.stories.tsx
@@ -6,6 +6,8 @@ import { storiesOf } from '@storybook/react';
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 // COMPONENTS
 import {
+    responsiveValues,
+    responsiveQuery,
     Container,
     Row,
     Col,
@@ -13,7 +15,7 @@ import {
     ScreenClass,
     ScreenBadge,
     Hidden,
-} from '../../Grid';
+} from './';
 import { Typography } from '../../Typography';
 // README
 import * as README from './README.md';
@@ -21,6 +23,45 @@ import { RootTheme } from '../../theme';
 
 const StyledStory = styled('div')`
     padding: 2rem 5rem;
+`;
+
+const ResponsiveQueryExample = styled('div')`
+    padding: 1rem;
+    ${props => responsiveQuery(props, responsiveValues.xs)`
+        background-color: red;
+
+        .anchor-typography {
+            color: #00FFFF;
+        }
+    `}
+    ${props => responsiveQuery(props, responsiveValues.sm)`
+        background-color: orange;
+
+        .anchor-typography {
+            color: #005AFF;
+        }
+    `}
+    ${props => responsiveQuery(props, responsiveValues.md)`
+        background-color: yellow;
+
+        .anchor-typography {
+            color: #0000FF;
+        }
+    `}
+    ${props => responsiveQuery(props, responsiveValues.lg)`
+        background-color: green;
+
+        .anchor-typography {
+            color: #FF7FFF;
+        }
+    `}
+    ${props => responsiveQuery(props, responsiveValues.xl)`
+        background-color: blue;
+
+        .anchor-typography {
+            color: #FFFF00;
+        }
+    `}
 `;
 
 storiesOf('Components/Grid/Responsive', module)
@@ -127,5 +168,16 @@ storiesOf('Components/Grid/Responsive', module)
                     <ScreenBadge />
                 </Container>
             </StyledStory>
+        </ThemeProvider>
+    ))
+    .add('responsiveQuery', () => (
+        <ThemeProvider theme={RootTheme}>
+            <ResponsiveQueryExample>
+                <Typography tag="h1">Resize The Window</Typography>
+                <Typography tag="p" pt="2">
+                    For each breakpoint, xs | sm | md | lg | xl, a new media
+                    query is generated.
+                </Typography>
+            </ResponsiveQueryExample>
         </ThemeProvider>
     ));

--- a/src/Grid/Grid/index.ts
+++ b/src/Grid/Grid/index.ts
@@ -1,5 +1,7 @@
 // VENDOR
 export {
+    responsiveValues,
+    responsiveQuery,
     Col,
     Visible,
     Hidden,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -139,14 +139,14 @@ declare module 'react-awesome-styled-grid' {
 
     type ColVal = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-    interface ResponsiveProps {
+    export interface ResponsiveProps {
         xs?: ColVal;
         sm?: ColVal;
         md?: ColVal;
         lg?: ColVal;
         xl?: ColVal;
     }
-    interface VisibleProps extends HTMLAttributes<HTMLDivElement> {
+    export interface VisibleProps extends HTMLAttributes<HTMLDivElement> {
         xs?: boolean;
         sm?: boolean;
         md?: boolean;
@@ -157,7 +157,9 @@ declare module 'react-awesome-styled-grid' {
 
     type ResponsiveArrayValues = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
-    interface ColProps extends ResponsiveProps, HTMLAttributes<HTMLDivElement> {
+    export interface ColProps
+        extends ResponsiveProps,
+            HTMLAttributes<HTMLDivElement> {
         offset?: ResponsiveProps;
         reverse?: ResponsiveArrayValues[];
         debug?: boolean;
@@ -167,6 +169,16 @@ declare module 'react-awesome-styled-grid' {
         render: (resolution: ResponsiveArrayValues) => any;
     }
 
+    interface ConfigKeys {
+        breakpoints: object;
+        columns: object;
+        container: object;
+        gutterWidth: object;
+        media: object;
+        mediaQuery: string;
+        paddingWidth: object;
+    }
+
     export const Row: FunctionComponent<HTMLAttributes<HTMLDivElement>>;
     export const Col: FunctionComponent<ColProps>;
     export const Container: FunctionComponent<HTMLAttributes<HTMLDivElement>>;
@@ -174,4 +186,5 @@ declare module 'react-awesome-styled-grid' {
     export const Hidden: FunctionComponent<VisibleProps>;
     export const ScreenClass: FunctionComponent<ScreenClassProps>;
     export const ScreenBadge: FunctionComponent<HTMLAttributes<HTMLDivElement>>;
+    export function config(props: object): ConfigKeys;
 }


### PR DESCRIPTION
chore: bumped to v1.0.4

chore(typings): exported several interface's for react-awesome-styled-grid, added entry for config

feat(Grid): exposed config's media query abilities with a utility function, responsiveQuery

docs(Grid): added responsiveQuery story

chore: linted

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

New utility function available, `responsiveQuery`, which allows easy creation of mediaQuery's based on Grid's xs, sm, md, etc, breakpoints.

Added explicit declarations of props/interfaces for existing Grid components: Hidden, Visible, Col.
