### PR TITLE
feat: adds search to docsite

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,5 +7,5 @@ yarn-error.log
 /public
 .DS_Store
 
-# TODO: remove this once the scraper finds a permanent home
+# Temporary exclusion until I decide where this repo and its docker image live
 docsearch-scraper

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -42,7 +42,7 @@ module.exports = {
         respectDNT: true,
         siteSpeedSampleRate: 10
       },
-    },
+    }
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,6 +7,7 @@
         "@retailmenot/anchor": "^1.1.0",
         "@xstyled/styled-components": "1.10.0",
         "@xstyled/system": "1.10.0",
+        "algoliasearch": "^3.35.1",
         "babel-plugin-styled-components": "^1.10.6",
         "classnames": "^2.2.6",
         "gatsby": "^2.13.60",
@@ -22,6 +23,7 @@
         "gatsby-source-filesystem": "^2.0.33",
         "gatsby-transformer-sharp": "^2.1.19",
         "html-react-parser": "^0.9.1",
+        "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.2",
         "prism-react-renderer": "^0.1.7",
         "react": "^16.10.2",
@@ -44,11 +46,14 @@
         "develop": "gatsby develop",
         "start": "npm run develop",
         "lint": "prettier --write \"./?(src|components)/**/*.tsx\"",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "scrape": "docker run -it --env-file=\"./docsearch-scraper/.env\" -e \"CONFIG=$(cat ./docsearch-scraper/config.json | jq -r tostring)\" algolia/docsearch-scraper"
     },
     "devDependencies": {
         "@mdx-js/loader": "^0.20.3",
         "@mdx-js/mdx": "^0.20.3",
+        "@types/algoliasearch": "^3.34.5",
+        "@types/lodash.debounce": "^4.0.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/react-copy-to-clipboard": "^4.2.6",
         "@types/react-helmet": "^5.0.11",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "author": "Kameron (@sharkparty), Steve (@zero0Halo)",
     "dependencies": {
         "@reach/component-component": "^0.1.3",
-        "@retailmenot/anchor": "^1.1.0",
+        "@retailmenot/anchor": "^1.1.2",
         "@xstyled/styled-components": "1.10.0",
         "@xstyled/system": "1.10.0",
         "algoliasearch": "^3.35.1",

--- a/docs/src/components/Layout/Page/Page.component.tsx
+++ b/docs/src/components/Layout/Page/Page.component.tsx
@@ -26,6 +26,7 @@ import {
     EnhancedNextPrevious,
 } from '../../Navigation';
 import { MDXComponents } from './MDXComponents';
+import { SearchInput } from '../../SearchInput';
 import { breakpoints, rem } from '../../Utils';
 // ASSETS
 import logo from './anchor-logo.svg';
@@ -171,6 +172,20 @@ const HamburgerCol = styled(CenteredCol)`
     `}
 `;
 
+const LogoCol = styled(CenteredCol)`
+    padding-right: 0;
+`;
+
+// TODO: This is a stopgap measure to get search out. The current mobile layout, plus the way
+// DocSearch initializes, makes both the UX and UI for mobile search tricky. Hiding it for mobile
+// for now
+const SearchCol = styled(CenteredCol)`
+    display: none;
+    ${props => config(props).media[breakpoints.md]`
+        display: flex;
+    `}
+`;
+
 const AnchorDocsTheme = merge({}, RootTheme, {
     colors: {
         primary: {
@@ -182,6 +197,11 @@ const AnchorDocsTheme = merge({}, RootTheme, {
             base: '#EB663D',
             light: '#FA9F5A',
             dark: '#C74E30',
+        },
+        accent: {
+            base: '#E3EEF6',
+            light: '#0998D6',
+            dark: '#0074A6',
         },
         borders: {
             light: '#F1F1F1',
@@ -255,20 +275,20 @@ export const Page = ({
                                 />
                             </HamburgerCol>
 
-                            <CenteredCol md={2} xs={2} sm={4}>
+                            <LogoCol md={2} lg={3} xl={2}>
                                 <StyledLogoContainer to="/">
                                     <img
                                         alt="Anchor Logo Horizontal"
                                         src={logo}
                                     />
                                 </StyledLogoContainer>
-                            </CenteredCol>
+                            </LogoCol>
 
-                            <CenteredCol md={2} xs={1} sm={1}>
-                                {/* TODO: Search will go here */}
-                            </CenteredCol>
+                            <SearchCol>
+                                <SearchInput />
+                            </SearchCol>
 
-                            <CenteredCol md={4} xs={1} sm={3}>
+                            <CenteredCol>
                                 <StyledPrimaryNav>
                                     <Typography
                                         tag="a"
@@ -285,7 +305,7 @@ export const Page = ({
                 </StyledHeader>
 
                 <Row>
-                    <SectionNavCol md={2} lg={2}>
+                    <SectionNavCol md={2} lg={3} xl={2}>
                         <FixedBody sectionNavOpen={sectionNavOpen} />
 
                         <StyledSectionNav sectionNavOpen={sectionNavOpen}>
@@ -293,7 +313,7 @@ export const Page = ({
                         </StyledSectionNav>
                     </SectionNavCol>
 
-                    <Col md={6} lg={10}>
+                    <Col md={6} lg={9} xl={10}>
                         <StyledContentMain>
                             <br />
                             <MDXProvider components={MDXComponents}>

--- a/docs/src/components/Navigation/SectionNavigation/SectionNavigation.component.tsx
+++ b/docs/src/components/Navigation/SectionNavigation/SectionNavigation.component.tsx
@@ -17,9 +17,8 @@ const StyledCollapseGroup = styled(CollapseGroup)`
         text-decoration: none;
 
         &.active {
-            /* TODO: When we have a dedicated theme provider these colors should be moved into it. */
-            background-color: #e3eef6;
-            color: accent.base;
+            background-color: accent.base;
+            color: accent.light;
         }
     }
 `;

--- a/docs/src/components/SearchInput/SearchInput.component.tsx
+++ b/docs/src/components/SearchInput/SearchInput.component.tsx
@@ -1,0 +1,164 @@
+/*
+    This component leverages Algolia's search API along with their DocSearch service.
+    http://anchor.retailmenot.design is scraped every 24 hours by DocSearch, and that scraped data
+    is fed into an Algolia index which, for now, only I (steve.swanson@rmn.com), have direct access
+    to. This component uses Algolia's API to then query that index to provide the user with results.
+*/
+
+// VENDOR
+import * as React from 'react';
+import * as algoliasearch from 'algoliasearch';
+import debounce from 'lodash.debounce';
+// ANCHOR & COMPONENTS
+import { AutoComplete, Search as SearchIcon } from '@retailmenot/anchor';
+import { ITEM_TYPES } from '../Utils';
+
+const APP_ID = 'BH4D9OD16A';
+const API_KEY = '38f9dd2e7cc8c05d97c1caa5c3ecb7cc';
+const INDEX_NAME = 'retailmenot_anchor';
+const DEBOUNCE_DELAY = 150;
+const NUMBER_OF_RESULTS = 5;
+
+type ItemType = keyof typeof ITEM_TYPES;
+
+type AlgoliaHit = {
+    anchor: string;
+    content: string;
+    hierarchy: object;
+    url: string;
+    objectID: string;
+};
+
+type DataSet = {
+    label: string;
+    id: string;
+    url?: string;
+    listItemType?: ItemType;
+};
+
+interface InitialState {
+    client?: any;
+    index?: object | boolean;
+    dataSource?: [DataSet];
+}
+
+export class SearchInput extends React.PureComponent<InitialState> {
+    readonly state = {
+        client: undefined,
+        index: {},
+        dataSource: [],
+    };
+
+    constructor(props: object) {
+        super(props);
+
+        this.goTo = this.goTo.bind(this);
+
+        this.searchIndex = debounce(
+            this.searchIndex.bind(this),
+            DEBOUNCE_DELAY
+        );
+    }
+
+    componentDidMount() {
+        // Initializes Algolia's API and assigns it to state
+        const client = algoliasearch(APP_ID, API_KEY);
+        const index = client.initIndex(INDEX_NAME);
+
+        this.setState({
+            client,
+            index,
+        });
+    }
+
+    // Searches the Algolia index and formats the results for the Autocomplete component
+    async searchIndex(val: string) {
+        const { index } = this.state;
+        const dataSource: DataSet[] = [];
+
+        /*
+            Searches Algolia index for results.
+            TODO: Typescript error based on the fact that index doesn't have the search property
+            initially. Gating it doesn't fix the issue.
+        */
+        const results = await index.search({
+            query: val,
+            hitsPerPage: NUMBER_OF_RESULTS,
+        });
+
+        if (results) {
+            // 'hits' is an Algolia term for matching results
+            const { hits } = results;
+            let previousSection = '';
+
+            // TODO: This probably could be converted to use .reduce, but moving quickly
+            hits.forEach((hit: AlgoliaHit) => {
+                /*
+                    Algolia's scraper ranks search terms/sections in a hierarchy (lvl0-lvl5) lvl0
+                    is higher up in the page tree, i.e. COMPONENTS, whereas lvl5 might be a code
+                    sample title. This extracts those values to make the search results for
+                    Autocomplete.
+                */
+                const hitValues = Object.values(hit.hierarchy);
+                // This is the main section of the site and will be a title not a linked result.
+                const hitSection = hitValues.shift();
+                // Joins the rest of the hit hierarchy values, filtering out nulls.
+                const hitLabel = hitValues
+                    .filter((value: string) => value !== null)
+                    .join(' > ');
+
+                /*
+                    Don't want titles repeated if they're right next to each other. The order of
+                    Algolia's results appear to be based on relevance, so it's possible that further
+                    down the list the same title will appear.
+                */
+                if (hitSection !== previousSection) {
+                    dataSource.push({
+                        label: hitSection,
+                        id: `${hit.objectID}-title`,
+                        listItemType: ITEM_TYPES.title,
+                    });
+                }
+
+                dataSource.push({
+                    label: hitLabel,
+                    id: hit.objectID,
+                    url: hit.url,
+                    listItemType: ITEM_TYPES.item,
+                });
+
+                previousSection = hitSection;
+            });
+
+            this.setState({ dataSource });
+        }
+    }
+
+    // Using the label that was selected, uses the associated url and redirects to that page.
+    goTo(value: string) {
+        const result = this.state.dataSource.find((item: DataSet) => {
+            return value === item.label;
+        });
+
+        if (result) {
+            // TODO: TypeScript zinging me here even with a gate.
+            location = result.url;
+        }
+    }
+
+    render() {
+        const { goTo, searchIndex } = this;
+        const { dataSource } = this.state;
+
+        return (
+            <AutoComplete
+                dataSource={dataSource}
+                onFilter={searchIndex}
+                onSelect={goTo}
+                placeholder="Search"
+                prefix={<SearchIcon />}
+                size="sm"
+            />
+        );
+    }
+}

--- a/docs/src/components/SearchInput/SearchInput.component.tsx
+++ b/docs/src/components/SearchInput/SearchInput.component.tsx
@@ -156,7 +156,7 @@ export class SearchInput extends React.PureComponent<InitialState> {
                 onFilter={searchIndex}
                 onSelect={goTo}
                 placeholder="Search"
-                prefix={<SearchIcon />}
+                prefix={<SearchIcon pl="2" />}
                 size="sm"
             />
         );

--- a/docs/src/components/SearchInput/index.ts
+++ b/docs/src/components/SearchInput/index.ts
@@ -1,0 +1,1 @@
+export { SearchInput } from './SearchInput.component';

--- a/docs/src/components/Utils/constants.ts
+++ b/docs/src/components/Utils/constants.ts
@@ -9,3 +9,9 @@ export enum TEXT_ALIGNMENT {
     left = 'left',
     right = 'right',
 }
+
+export enum ITEM_TYPES {
+    divider = 'divider',
+    item = 'item',
+    title = 'title',
+}

--- a/docs/src/components/Utils/rgba.ts
+++ b/docs/src/components/Utils/rgba.ts
@@ -1,0 +1,14 @@
+// Based off of https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
+
+export function rgba(hex: string, opacity: number) {
+    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+
+    if (result) {
+        const r = parseInt(result[1], 16);
+        const g = parseInt(result[2], 16);
+        const b = parseInt(result[3], 16);
+        return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+    }
+
+    return hex;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Icon/utils.ts
+++ b/src/Icon/utils.ts
@@ -1,10 +1,12 @@
 // VENDOR
 import styled, { css } from '@xstyled/styled-components';
-import { margin as marginStyles } from '@xstyled/system';
+import { space as spaceStyles, SpaceProps } from '@xstyled/system';
 
 type ScaleFactors = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
-export interface IconSVGProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface IconSVGProps
+    extends React.HTMLAttributes<HTMLSpanElement>,
+        SpaceProps {
     scale?: ScaleFactors;
     color?: string;
     className?: string;
@@ -28,7 +30,7 @@ export const DefaultColor = 'currentColor';
 export const DefaultScale = 'md';
 
 export const StyledIcon = styled('span')<StyledIconSVGProps>`
-    ${marginStyles};
+    ${spaceStyles};
     display: inline-block;
     height: ${({ scale = 'md' }) => `${Scale[scale] / 16}rem`};
     width: ${({ scale = 'md' }) => `${Scale[scale] / 16}rem`};


### PR DESCRIPTION
feat(rgba): new util. takes a hex code and opacity level and returns a css rgba string

chore(SearchInput): converted many css elements into styled components

chore(gitignore): added docsearch-scraper directory

fix(Page): used named export for Helmet

feat(scrape): added scrape script to package.json

chore: cleanup

feat(Page): added accent colors to the theme

fix(SectionNav): used accent colors from theme

fix(Page): better responsive breakpoint implementation

chore(Page): search is disabled for mobile

Clearly this is not ideal, but want to roll search out then add this in

chore: added algoliasearch and and lodash.debounce modules

feat(SearchInput): complete rewrite. Now directly uses Algolia api to hit docsearch index

feat(Results): new component. used by SearchInput as a template for search results.

chore: code cleanup

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

This adds search to the doc site. This works in two parts:

* https://anchor.retailmenot.design/ is added to the DocSearch registry and managed by Algolia. They routinely scrape our site and populate an Algolia index which (for now) only I have direct access to.
* Using Algolia's API, I query the index and feed that info into an `AutoComplete` component.

The biggest caveat is that I'm hiding the search box on mobile. That's a big TODO, but this push is the first step.
