### PR TITLE
feat(Icon): add spacing props to icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Icon/utils.ts
+++ b/src/Icon/utils.ts
@@ -1,10 +1,12 @@
 // VENDOR
 import styled, { css } from '@xstyled/styled-components';
-import { margin as marginStyles } from '@xstyled/system';
+import { space as spaceStyles, SpaceProps } from '@xstyled/system';
 
 type ScaleFactors = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
-export interface IconSVGProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface IconSVGProps
+    extends React.HTMLAttributes<HTMLSpanElement>,
+        SpaceProps {
     scale?: ScaleFactors;
     color?: string;
     className?: string;
@@ -28,7 +30,7 @@ export const DefaultColor = 'currentColor';
 export const DefaultScale = 'md';
 
 export const StyledIcon = styled('span')<StyledIconSVGProps>`
-    ${marginStyles};
+    ${spaceStyles};
     display: inline-block;
     height: ${({ scale = 'md' }) => `${Scale[scale] / 16}rem`};
     width: ${({ scale = 'md' }) => `${Scale[scale] / 16}rem`};


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------

Adds spacing props to icons
