### PR TITLE
fix: autocomplete input warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -194,9 +194,12 @@ const eventTypeResolver = (
 
     switch (type) {
         case 'number':
+            // Although counter-intuitive, to properly clear an input field with type number it must
+            // be fed an empty string.
             handler(inputValue ? parseFloat(inputValue) : '', event);
             break;
         case 'text':
+            // An empty inputValue would be null which React doesn't handle well.
             handler(inputValue || '', event);
             break;
         default:

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -191,15 +191,16 @@ const eventTypeResolver = (
     type: InputTypes
 ) => {
     const inputValue = get(event, 'target.value');
+
     switch (type) {
         case 'number':
-            handler(inputValue ? parseFloat(inputValue) : null, event);
+            handler(inputValue ? parseFloat(inputValue) : '', event);
             break;
         case 'text':
-            handler(inputValue, event);
+            handler(inputValue || '', event);
             break;
         default:
-            handler(inputValue, event);
+            handler(inputValue || '', event);
             break;
     }
 };

--- a/src/Form/Input/Input.stories.tsx
+++ b/src/Form/Input/Input.stories.tsx
@@ -16,11 +16,19 @@ const StyledStory = styled('div')`
     padding: 2rem 5rem;
 `;
 
+type InputState = {
+    text?: string;
+    number?: string | number;
+    tel?: string | number;
+};
+
 const InputStories = () => {
     const { useState } = React;
-    const [textInputVal, setTextInputVal] = useState<string>('');
-    const [numberInputVal, setNumberInputVal] = useState<number | string>('');
-    const [phoneInputVal, setPhoneInputVal] = useState<number | string>('');
+    const [inputValues, setInputValues] = useState<InputState>({
+        text: '',
+        number: '',
+        tel: '',
+    });
 
     return (
         <ThemeProvider theme={RootTheme}>
@@ -31,13 +39,13 @@ const InputStories = () => {
                             placeholder="Enter text here"
                             label="Enter text here"
                             type="text"
-                            value={textInputVal}
-                            onChange={newVal => setTextInputVal(newVal)}
+                            value={inputValues.text}
+                            onChange={newVal => setInputValues({ ...inputValues, text: newVal })}
                         />
                         <Button
                             size="sm"
                             onClick={() => {
-                                setTextInputVal('');
+                                setInputValues({ ...inputValues, text: '' });
                             }}
                         >
                             Clear text input
@@ -48,8 +56,8 @@ const InputStories = () => {
                             placeholder="Enter a number here"
                             type="number"
                             suffix={<Search color="text.placeholder" />}
-                            value={numberInputVal}
-                            onChange={newVal => setNumberInputVal(newVal)}
+                            value={inputValues.number}
+                            onChange={newVal => setInputValues({ ...inputValues, number: newVal })}
                         />
                     </div>
                     <div>
@@ -58,8 +66,8 @@ const InputStories = () => {
                             label="Enter a phone number here"
                             prefix={<Mobile color="text.placeholder" />}
                             type="tel"
-                            value={phoneInputVal}
-                            onChange={newVal => setPhoneInputVal(newVal)}
+                            value={inputValues.tel}
+                            onChange={newVal => setInputValues({ ...inputValues, tel: newVal })}
                         />
                     </div>
                     <div>

--- a/src/Form/Input/Input.stories.tsx
+++ b/src/Form/Input/Input.stories.tsx
@@ -40,7 +40,9 @@ const InputStories = () => {
                             label="Enter text here"
                             type="text"
                             value={inputValues.text}
-                            onChange={newVal => setInputValues({ ...inputValues, text: newVal })}
+                            onChange={newVal =>
+                                setInputValues({ ...inputValues, text: newVal })
+                            }
                         />
                         <Button
                             size="sm"
@@ -57,7 +59,12 @@ const InputStories = () => {
                             type="number"
                             suffix={<Search color="text.placeholder" />}
                             value={inputValues.number}
-                            onChange={newVal => setInputValues({ ...inputValues, number: newVal })}
+                            onChange={newVal =>
+                                setInputValues({
+                                    ...inputValues,
+                                    number: newVal,
+                                })
+                            }
                         />
                     </div>
                     <div>
@@ -67,7 +74,9 @@ const InputStories = () => {
                             prefix={<Mobile color="text.placeholder" />}
                             type="tel"
                             value={inputValues.tel}
-                            onChange={newVal => setInputValues({ ...inputValues, tel: newVal })}
+                            onChange={newVal =>
+                                setInputValues({ ...inputValues, tel: newVal })
+                            }
                         />
                     </div>
                     <div>

--- a/src/Form/Input/Input.stories.tsx
+++ b/src/Form/Input/Input.stories.tsx
@@ -18,7 +18,10 @@ const StyledStory = styled('div')`
 
 const InputStories = () => {
     const { useState } = React;
-    const [someInputVal, setSomeInputVal] = useState<string>('');
+    const [textInputVal, setTextInputVal] = useState<string>('');
+    const [numberInputVal, setNumberInputVal] = useState<number | string>('');
+    const [phoneInputVal, setPhoneInputVal] = useState<number | string>('');
+
     return (
         <ThemeProvider theme={RootTheme}>
             <StyledStory>
@@ -28,13 +31,13 @@ const InputStories = () => {
                             placeholder="Enter text here"
                             label="Enter text here"
                             type="text"
-                            value={someInputVal}
-                            onChange={newVal => setSomeInputVal(newVal)}
+                            value={textInputVal}
+                            onChange={newVal => setTextInputVal(newVal)}
                         />
                         <Button
                             size="sm"
                             onClick={() => {
-                                setSomeInputVal('');
+                                setTextInputVal('');
                             }}
                         >
                             Clear text input
@@ -45,6 +48,8 @@ const InputStories = () => {
                             placeholder="Enter a number here"
                             type="number"
                             suffix={<Search color="text.placeholder" />}
+                            value={numberInputVal}
+                            onChange={newVal => setNumberInputVal(newVal)}
                         />
                     </div>
                     <div>
@@ -53,6 +58,8 @@ const InputStories = () => {
                             label="Enter a phone number here"
                             prefix={<Mobile color="text.placeholder" />}
                             type="tel"
+                            value={phoneInputVal}
+                            onChange={newVal => setPhoneInputVal(newVal)}
                         />
                     </div>
                     <div>


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

This fixes a very loud warning from React regarding uncontrolled components for the `Input` component, which in turn fixes the same warning from `AutoComplete` since it uses `Input`.
