### PR TITLE
feat: autocomplete debug prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -16,6 +16,7 @@ type AutoCompleteDataSource = Array<{
 }>;
 
 interface AutoCompleteProps {
+    debug?: boolean;
     name?: string;
     dataSource?: AutoCompleteDataSource | string[] | number[];
     className?: string;
@@ -96,6 +97,7 @@ const StyledAutoComplete = styled('div')<StyledAutoCompleteProps>`
 
 export const AutoComplete = ({
     name = '',
+    debug = false,
     className,
     placeholder,
     // children,
@@ -213,7 +215,7 @@ export const AutoComplete = ({
                 name="auto-complete"
                 className="auto-complete-input"
             />
-            {isFocused && dataSource.length > 0 && (
+            { (isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer
                     size={size}
                     ref={resultsRef}

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -215,7 +215,7 @@ export const AutoComplete = ({
                 name="auto-complete"
                 className="auto-complete-input"
             />
-            { (isFocused || debug) && dataSource.length > 0 && (
+            {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer
                     size={size}
                     ref={resultsRef}

--- a/src/AutoComplete/AutoComplete.stories.tsx
+++ b/src/AutoComplete/AutoComplete.stories.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 // STORYBOOK
 import { storiesOf } from '@storybook/react';
+import { boolean } from '@storybook/addon-knobs';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 // COMPONENTS
@@ -47,6 +48,7 @@ const StateBasedAutoCompleteStory = () => {
                         <Typography tag="h1">AutoComplete 1</Typography>
                         <br />
                         <AutoComplete
+                            debug={boolean('debug', false)}
                             placeholder="Search here..."
                             onFilter={(newTerm: any) => {
                                 setTempData(tempDataStringSource(newTerm));
@@ -90,6 +92,7 @@ const StateBasedAutoCompleteStoryCustomResult = () => {
                         <Typography tag="h1">AutoComplete 1</Typography>
                         <br />
                         <AutoComplete
+                            debug={boolean('debug', false)}
                             placeholder="Search here..."
                             onFilter={(newTerm: any) => {
                                 setTempData(tempDataStringSource(newTerm));
@@ -123,6 +126,7 @@ storiesOf('Components/AutoComplete', module)
                         <Typography tag="h1">AutoComplete 1</Typography>
                         <br />
                         <AutoComplete
+                            debug={boolean('debug', false)}
                             allowClear={true}
                             placeholder="Search here..."
                             prefix={<Search color="borders.base" />}


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

When `debug` is true, it keeps the result list visible even when focus is lost. This is useful for development of custom result templates/styles as it's not possible for the user to inspect the results with dev tools (the list goes away on blur).
