### PR TITLE
feat(AutoComplete): Expose Input component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -16,39 +16,39 @@ type AutoCompleteDataSource = Array<{
 }>;
 
 interface AutoCompleteProps {
-    inputComponent?: any;
+    className?: string;
+    dataSource?: AutoCompleteDataSource | string[] | number[];
     debug?: boolean;
     name?: string;
-    dataSource?: AutoCompleteDataSource | string[] | number[];
-    className?: string;
-    size?: 'sm' | 'md' | 'lg';
     placeholder?: string;
+    size?: 'sm' | 'md' | 'lg';
     value?: string | number;
     // TODO: resultTemplate
     // TODO: allowClear
     allowClear?: boolean;
     // Visual
-    border?: boolean;
-    shadow?: boolean;
     background?: string;
+    border?: boolean;
     color?: string;
+    shadow?: boolean;
     // TODO: Allow children
     resultTemplate?: (props: any) => any;
-    suffix?: any;
+    inputComponent?: any;
     prefix?: any;
+    suffix?: any;
     // Event Handlers
-    onFilter?: (term: string | number) => void;
-    onSelect?: (value?: string | number, item?: any) => void;
-    onChange?: (value?: string | number, item?: any) => void;
-    onFocus?: (event?: React.FocusEvent) => void;
     onBlur?: (event?: React.FocusEvent) => void;
+    onChange?: (value?: string | number, item?: any) => void;
+    onFilter?: (term: string | number) => void;
+    onFocus?: (event?: React.FocusEvent) => void;
+    onSelect?: (value?: string | number, item?: any) => void;
 }
 
 interface StyledAutoCompleteProps {
-    shadow?: boolean;
-    border?: boolean;
     background?: string;
+    border?: boolean;
     color?: string;
+    shadow?: boolean;
 }
 
 const EventKeyCodes = {
@@ -165,58 +165,63 @@ export const AutoComplete = ({
             })}
             {...props}
         >
-            {
-                React.createElement(inputComponent, {
-                    ariaLabel: name.length
-                        ? `auto-complete-${name.toLowerCase()}`
-                        : 'auto-complete'
-                    ,
-                    value: term,
-                    ref: inputRef,
-                    size: size,
-                    prefix: prefix,
-                    suffix: suffix,
-                    placeholder: placeholder,
-                    onFocus: () => setIsFocused(true),
-                    onBlur: () => setIsFocused(false),
-                    onChange: (newValue: string) => {
-                        changeSearchTerm(newValue);
-                    },
-                    onKeyDown: (event: React.KeyboardEvent) => {
-                        switch (event.keyCode) {
-                            case EventKeyCodes.TAB:
-                            case EventKeyCodes.ENTER:
-                                event.preventDefault();
-                                event.stopPropagation();
-                                if (isFocused) {
-                                    // Unset initialTerm
-                                    resultsRef.current.clearInitialTerm();
-                                    // Set the active value of the autocomplete
-                                    resultsRef.current.selectActive();
-                                }
-                                break;
-                            case EventKeyCodes.ARROW_DOWN:
-                                event.preventDefault();
-                                event.stopPropagation();
-                                resultsRef.current.handleNext(term);
-                                break;
-                            case EventKeyCodes.ARROW_UP:
-                                event.preventDefault();
-                                event.stopPropagation();
-                                resultsRef.current.handlePrevious(term);
-                                break;
-                            default:
-                                if (resultsRef.current) {
-                                    resultsRef.current.clearInitialTerm();
-                                    resultsRef.current.setActiveIndex(0);
-                                }
-                                break;
-                        }
-                    },
-                    name: "auto-complete",
-                    className: "auto-complete-input",
-                })
-            }
+            {/*
+                    This can render a custom input component and passed props. This custom input
+                    must be wrapped in forwardRef for this to work. Uses Input by default. Ex:
+
+                    const CustomInput = React.forwardRef(
+                        ({...props}) => <Input {...props} autoCapitalize="off" />
+                    );
+                */
+            React.createElement(inputComponent, {
+                ariaLabel: name.length
+                    ? `auto-complete-${name.toLowerCase()}`
+                    : 'auto-complete',
+                value: term,
+                ref: inputRef,
+                size: size,
+                prefix: prefix,
+                suffix: suffix,
+                placeholder: placeholder,
+                onFocus: () => setIsFocused(true),
+                onBlur: () => setIsFocused(false),
+                onChange: (newValue: string) => {
+                    changeSearchTerm(newValue);
+                },
+                onKeyDown: (event: React.KeyboardEvent) => {
+                    switch (event.keyCode) {
+                        case EventKeyCodes.TAB:
+                        case EventKeyCodes.ENTER:
+                            event.preventDefault();
+                            event.stopPropagation();
+                            if (isFocused) {
+                                // Unset initialTerm
+                                resultsRef.current.clearInitialTerm();
+                                // Set the active value of the autocomplete
+                                resultsRef.current.selectActive();
+                            }
+                            break;
+                        case EventKeyCodes.ARROW_DOWN:
+                            event.preventDefault();
+                            event.stopPropagation();
+                            resultsRef.current.handleNext(term);
+                            break;
+                        case EventKeyCodes.ARROW_UP:
+                            event.preventDefault();
+                            event.stopPropagation();
+                            resultsRef.current.handlePrevious(term);
+                            break;
+                        default:
+                            if (resultsRef.current) {
+                                resultsRef.current.clearInitialTerm();
+                                resultsRef.current.setActiveIndex(0);
+                            }
+                            break;
+                    }
+                },
+                name: 'auto-complete',
+                className: 'auto-complete-input',
+            })}
 
             {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -217,57 +217,7 @@ export const AutoComplete = ({
                     className: "auto-complete-input",
                 })
             }
-            {/* <Input
-                ariaLabel={
-                    name.length
-                        ? `auto-complete-${name.toLowerCase()}`
-                        : 'auto-complete'
-                }
-                value={term}
-                ref={inputRef}
-                size={size}
-                prefix={prefix}
-                suffix={suffix}
-                placeholder={placeholder}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
-                onChange={(newValue: string) => {
-                    changeSearchTerm(newValue);
-                }}
-                onKeyDown={(event: React.KeyboardEvent) => {
-                    switch (event.keyCode) {
-                        case EventKeyCodes.TAB:
-                        case EventKeyCodes.ENTER:
-                            event.preventDefault();
-                            event.stopPropagation();
-                            if (isFocused) {
-                                // Unset initialTerm
-                                resultsRef.current.clearInitialTerm();
-                                // Set the active value of the autocomplete
-                                resultsRef.current.selectActive();
-                            }
-                            break;
-                        case EventKeyCodes.ARROW_DOWN:
-                            event.preventDefault();
-                            event.stopPropagation();
-                            resultsRef.current.handleNext(term);
-                            break;
-                        case EventKeyCodes.ARROW_UP:
-                            event.preventDefault();
-                            event.stopPropagation();
-                            resultsRef.current.handlePrevious(term);
-                            break;
-                        default:
-                            if (resultsRef.current) {
-                                resultsRef.current.clearInitialTerm();
-                                resultsRef.current.setActiveIndex(0);
-                            }
-                            break;
-                    }
-                }}
-                name="auto-complete"
-                className="auto-complete-input"
-            /> */}
+
             {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer
                     size={size}

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -16,6 +16,7 @@ type AutoCompleteDataSource = Array<{
 }>;
 
 interface AutoCompleteProps {
+    inputComponent?: any;
     debug?: boolean;
     name?: string;
     dataSource?: AutoCompleteDataSource | string[] | number[];
@@ -96,25 +97,25 @@ const StyledAutoComplete = styled('div')<StyledAutoCompleteProps>`
 `;
 
 export const AutoComplete = ({
-    name = '',
-    debug = false,
+    allowClear,
+    background = 'white',
+    border = true,
     className,
-    placeholder,
-    // children,
-    suffix,
-    prefix,
+    color = 'text.light',
     dataSource = [],
-    value = '',
+    debug = false,
+    inputComponent = Input,
+    name = '',
+    onChange = () => null,
     onFilter = () => null,
     onSelect = () => null,
-    onChange = () => null,
-    size = 'lg',
-    shadow = false,
-    border = true,
-    background = 'white',
-    color = 'text.light',
+    placeholder,
+    prefix,
     resultTemplate,
-    allowClear,
+    shadow = false,
+    size = 'lg',
+    suffix,
+    value = '',
     ...props
 }: AutoCompleteProps) => {
     // Flag for autocomplete focus
@@ -164,7 +165,59 @@ export const AutoComplete = ({
             })}
             {...props}
         >
-            <Input
+            {
+                React.createElement(inputComponent, {
+                    ariaLabel: name.length
+                        ? `auto-complete-${name.toLowerCase()}`
+                        : 'auto-complete'
+                    ,
+                    value: term,
+                    ref: inputRef,
+                    size: size,
+                    prefix: prefix,
+                    suffix: suffix,
+                    placeholder: placeholder,
+                    onFocus: () => setIsFocused(true),
+                    onBlur: () => setIsFocused(false),
+                    onChange: (newValue: string) => {
+                        changeSearchTerm(newValue);
+                    },
+                    onKeyDown: (event: React.KeyboardEvent) => {
+                        switch (event.keyCode) {
+                            case EventKeyCodes.TAB:
+                            case EventKeyCodes.ENTER:
+                                event.preventDefault();
+                                event.stopPropagation();
+                                if (isFocused) {
+                                    // Unset initialTerm
+                                    resultsRef.current.clearInitialTerm();
+                                    // Set the active value of the autocomplete
+                                    resultsRef.current.selectActive();
+                                }
+                                break;
+                            case EventKeyCodes.ARROW_DOWN:
+                                event.preventDefault();
+                                event.stopPropagation();
+                                resultsRef.current.handleNext(term);
+                                break;
+                            case EventKeyCodes.ARROW_UP:
+                                event.preventDefault();
+                                event.stopPropagation();
+                                resultsRef.current.handlePrevious(term);
+                                break;
+                            default:
+                                if (resultsRef.current) {
+                                    resultsRef.current.clearInitialTerm();
+                                    resultsRef.current.setActiveIndex(0);
+                                }
+                                break;
+                        }
+                    },
+                    name: "auto-complete",
+                    className: "auto-complete-input",
+                })
+            }
+            {/* <Input
                 ariaLabel={
                     name.length
                         ? `auto-complete-${name.toLowerCase()}`
@@ -214,7 +267,7 @@ export const AutoComplete = ({
                 }}
                 name="auto-complete"
                 className="auto-complete-input"
-            />
+            /> */}
             {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer
                     size={size}

--- a/src/AutoComplete/AutoComplete.stories.tsx
+++ b/src/AutoComplete/AutoComplete.stories.tsx
@@ -11,6 +11,7 @@ import { Search } from '../Icon';
 import { Item } from '../List';
 import { Typography } from '../Typography';
 import { RootTheme } from '../theme';
+import { Input } from '../Form/Input';
 // README
 import * as README from './README.md';
 // THEME
@@ -108,6 +109,8 @@ const StateBasedAutoCompleteStoryCustomResult = () => {
     );
 };
 
+const CustomInput = React.forwardRef(({...props}) => <Input {...props} autoCapitalize="off" />);
+
 storiesOf('Components/AutoComplete', module)
     .addParameters({
         readme: {
@@ -126,6 +129,7 @@ storiesOf('Components/AutoComplete', module)
                         <Typography tag="h1">AutoComplete 1</Typography>
                         <br />
                         <AutoComplete
+                            inputComponent={CustomInput}
                             debug={boolean('debug', false)}
                             allowClear={true}
                             placeholder="Search here..."

--- a/src/AutoComplete/AutoComplete.stories.tsx
+++ b/src/AutoComplete/AutoComplete.stories.tsx
@@ -11,7 +11,6 @@ import { Search } from '../Icon';
 import { Item } from '../List';
 import { Typography } from '../Typography';
 import { RootTheme } from '../theme';
-import { Input } from '../Form/Input';
 // README
 import * as README from './README.md';
 // THEME
@@ -109,8 +108,6 @@ const StateBasedAutoCompleteStoryCustomResult = () => {
     );
 };
 
-const CustomInput = React.forwardRef(({...props}) => <Input {...props} autoCapitalize="off" />);
-
 storiesOf('Components/AutoComplete', module)
     .addParameters({
         readme: {
@@ -129,7 +126,6 @@ storiesOf('Components/AutoComplete', module)
                         <Typography tag="h1">AutoComplete 1</Typography>
                         <br />
                         <AutoComplete
-                            inputComponent={CustomInput}
                             debug={boolean('debug', false)}
                             allowClear={true}
                             placeholder="Search here..."

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -301,6 +301,7 @@ export const Input = forwardRef(
                             value={inputValue}
                             type={type}
                             placeholder={placeholder}
+                            {...props}
                         />
                         {label && (
                             <Typography

--- a/src/Grid/Grid/Grid.component.tsx
+++ b/src/Grid/Grid/Grid.component.tsx
@@ -88,10 +88,10 @@ export const Grid = ({
     rows,
     ...props
 }: GridProps) => {
+    const hasWindow = typeof window !== 'undefined' && window.innerWidth;
     const [innerWidth, setInnerWidth] = React.useState<number>(
-        window ? window.innerWidth : 0
+        hasWindow ? window.innerWidth : 0
     );
-    const hasWindow = window && window.innerWidth;
     // Default behavior is to use the breakpoints defined in the theme, but if the user doesn't use
     // the ThemeProvider it instead uses the breakpoints in the RootTheme.
     const { breakpoints: unsortedBreakpoints } =


### PR DESCRIPTION
feat: adds a new prop to AutoComplete, inputComponent. Defaults to Input.

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

This adds a new prop, `inputComponent` to `AutoComplete`. It defaults to use the `Input` component, but it allows the user to pass their own `Input` component provided they set up a `forwardRef`. Comments are in the code, documentation updates forthcoming.

This also fixes a rendering issue with Gatsby for `Grid`. Gatsby hates `window` and although I tested for its existence it was a truthiness test and was (apparently) not specific enough.
