### PR TITLE
feat: autocomplete input props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/AutoComplete/AutoComplete.component.spec.tsx
+++ b/src/AutoComplete/AutoComplete.component.spec.tsx
@@ -70,4 +70,15 @@ describe('Component: AutoComplete', () => {
         const tree = renderer.create(subject).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    it('should pass additional input attributes via inputProps', () => {
+        const subject = (
+            <ThemeProvider theme={RootTheme}>
+                <AutoComplete inputProps={{ autoCapitalize: 'false' }} />
+            </ThemeProvider>
+        );
+        const wrapper = mount(subject);
+
+        expect(wrapper.find({ autoCapitalize: 'false' })).toBeDefined();
+    });
 });

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -16,39 +16,39 @@ type AutoCompleteDataSource = Array<{
 }>;
 
 interface AutoCompleteProps {
-    inputComponent?: any;
+    className?: string;
+    dataSource?: AutoCompleteDataSource | string[] | number[];
     debug?: boolean;
     name?: string;
-    dataSource?: AutoCompleteDataSource | string[] | number[];
-    className?: string;
-    size?: 'sm' | 'md' | 'lg';
     placeholder?: string;
+    size?: 'sm' | 'md' | 'lg';
     value?: string | number;
     // TODO: resultTemplate
     // TODO: allowClear
     allowClear?: boolean;
     // Visual
-    border?: boolean;
-    shadow?: boolean;
     background?: string;
+    border?: boolean;
     color?: string;
+    shadow?: boolean;
     // TODO: Allow children
     resultTemplate?: (props: any) => any;
-    suffix?: any;
+    inputComponent?: any;
     prefix?: any;
+    suffix?: any;
     // Event Handlers
-    onFilter?: (term: string | number) => void;
-    onSelect?: (value?: string | number, item?: any) => void;
-    onChange?: (value?: string | number, item?: any) => void;
-    onFocus?: (event?: React.FocusEvent) => void;
     onBlur?: (event?: React.FocusEvent) => void;
+    onChange?: (value?: string | number, item?: any) => void;
+    onFilter?: (term: string | number) => void;
+    onFocus?: (event?: React.FocusEvent) => void;
+    onSelect?: (value?: string | number, item?: any) => void;
 }
 
 interface StyledAutoCompleteProps {
-    shadow?: boolean;
-    border?: boolean;
     background?: string;
+    border?: boolean;
     color?: string;
+    shadow?: boolean;
 }
 
 const EventKeyCodes = {
@@ -165,58 +165,63 @@ export const AutoComplete = ({
             })}
             {...props}
         >
-            {
-                React.createElement(inputComponent, {
-                    ariaLabel: name.length
-                        ? `auto-complete-${name.toLowerCase()}`
-                        : 'auto-complete'
-                    ,
-                    value: term,
-                    ref: inputRef,
-                    size: size,
-                    prefix: prefix,
-                    suffix: suffix,
-                    placeholder: placeholder,
-                    onFocus: () => setIsFocused(true),
-                    onBlur: () => setIsFocused(false),
-                    onChange: (newValue: string) => {
-                        changeSearchTerm(newValue);
-                    },
-                    onKeyDown: (event: React.KeyboardEvent) => {
-                        switch (event.keyCode) {
-                            case EventKeyCodes.TAB:
-                            case EventKeyCodes.ENTER:
-                                event.preventDefault();
-                                event.stopPropagation();
-                                if (isFocused) {
-                                    // Unset initialTerm
-                                    resultsRef.current.clearInitialTerm();
-                                    // Set the active value of the autocomplete
-                                    resultsRef.current.selectActive();
-                                }
-                                break;
-                            case EventKeyCodes.ARROW_DOWN:
-                                event.preventDefault();
-                                event.stopPropagation();
-                                resultsRef.current.handleNext(term);
-                                break;
-                            case EventKeyCodes.ARROW_UP:
-                                event.preventDefault();
-                                event.stopPropagation();
-                                resultsRef.current.handlePrevious(term);
-                                break;
-                            default:
-                                if (resultsRef.current) {
-                                    resultsRef.current.clearInitialTerm();
-                                    resultsRef.current.setActiveIndex(0);
-                                }
-                                break;
-                        }
-                    },
-                    name: "auto-complete",
-                    className: "auto-complete-input",
-                })
-            }
+            {/*
+                    This can render a custom input component and passed props. This custom input
+                    must be wrapped in forwardRef for this to work. Uses Input by default. Ex:
+
+                    const CustomInput = React.forwardRef(
+                        ({...props}) => <Input {...props} autoCapitalize="off" />
+                    );
+                */
+            React.createElement(inputComponent, {
+                ariaLabel: name.length
+                    ? `auto-complete-${name.toLowerCase()}`
+                    : 'auto-complete',
+                value: term,
+                ref: inputRef,
+                size: size,
+                prefix: prefix,
+                suffix: suffix,
+                placeholder: placeholder,
+                onFocus: () => setIsFocused(true),
+                onBlur: () => setIsFocused(false),
+                onChange: (newValue: string) => {
+                    changeSearchTerm(newValue);
+                },
+                onKeyDown: (event: React.KeyboardEvent) => {
+                    switch (event.keyCode) {
+                        case EventKeyCodes.TAB:
+                        case EventKeyCodes.ENTER:
+                            event.preventDefault();
+                            event.stopPropagation();
+                            if (isFocused) {
+                                // Unset initialTerm
+                                resultsRef.current.clearInitialTerm();
+                                // Set the active value of the autocomplete
+                                resultsRef.current.selectActive();
+                            }
+                            break;
+                        case EventKeyCodes.ARROW_DOWN:
+                            event.preventDefault();
+                            event.stopPropagation();
+                            resultsRef.current.handleNext(term);
+                            break;
+                        case EventKeyCodes.ARROW_UP:
+                            event.preventDefault();
+                            event.stopPropagation();
+                            resultsRef.current.handlePrevious(term);
+                            break;
+                        default:
+                            if (resultsRef.current) {
+                                resultsRef.current.clearInitialTerm();
+                                resultsRef.current.setActiveIndex(0);
+                            }
+                            break;
+                    }
+                },
+                name: 'auto-complete',
+                className: 'auto-complete-input',
+            })}
 
             {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -217,57 +217,7 @@ export const AutoComplete = ({
                     className: "auto-complete-input",
                 })
             }
-            {/* <Input
-                ariaLabel={
-                    name.length
-                        ? `auto-complete-${name.toLowerCase()}`
-                        : 'auto-complete'
-                }
-                value={term}
-                ref={inputRef}
-                size={size}
-                prefix={prefix}
-                suffix={suffix}
-                placeholder={placeholder}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
-                onChange={(newValue: string) => {
-                    changeSearchTerm(newValue);
-                }}
-                onKeyDown={(event: React.KeyboardEvent) => {
-                    switch (event.keyCode) {
-                        case EventKeyCodes.TAB:
-                        case EventKeyCodes.ENTER:
-                            event.preventDefault();
-                            event.stopPropagation();
-                            if (isFocused) {
-                                // Unset initialTerm
-                                resultsRef.current.clearInitialTerm();
-                                // Set the active value of the autocomplete
-                                resultsRef.current.selectActive();
-                            }
-                            break;
-                        case EventKeyCodes.ARROW_DOWN:
-                            event.preventDefault();
-                            event.stopPropagation();
-                            resultsRef.current.handleNext(term);
-                            break;
-                        case EventKeyCodes.ARROW_UP:
-                            event.preventDefault();
-                            event.stopPropagation();
-                            resultsRef.current.handlePrevious(term);
-                            break;
-                        default:
-                            if (resultsRef.current) {
-                                resultsRef.current.clearInitialTerm();
-                                resultsRef.current.setActiveIndex(0);
-                            }
-                            break;
-                    }
-                }}
-                name="auto-complete"
-                className="auto-complete-input"
-            /> */}
+
             {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer
                     size={size}

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -16,6 +16,7 @@ type AutoCompleteDataSource = Array<{
 }>;
 
 interface AutoCompleteProps {
+    inputComponent?: any;
     debug?: boolean;
     name?: string;
     dataSource?: AutoCompleteDataSource | string[] | number[];
@@ -96,25 +97,25 @@ const StyledAutoComplete = styled('div')<StyledAutoCompleteProps>`
 `;
 
 export const AutoComplete = ({
-    name = '',
-    debug = false,
+    allowClear,
+    background = 'white',
+    border = true,
     className,
-    placeholder,
-    // children,
-    suffix,
-    prefix,
+    color = 'text.light',
     dataSource = [],
-    value = '',
+    debug = false,
+    inputComponent = Input,
+    name = '',
+    onChange = () => null,
     onFilter = () => null,
     onSelect = () => null,
-    onChange = () => null,
-    size = 'lg',
-    shadow = false,
-    border = true,
-    background = 'white',
-    color = 'text.light',
+    placeholder,
+    prefix,
     resultTemplate,
-    allowClear,
+    shadow = false,
+    size = 'lg',
+    suffix,
+    value = '',
     ...props
 }: AutoCompleteProps) => {
     // Flag for autocomplete focus
@@ -164,7 +165,59 @@ export const AutoComplete = ({
             })}
             {...props}
         >
-            <Input
+            {
+                React.createElement(inputComponent, {
+                    ariaLabel: name.length
+                        ? `auto-complete-${name.toLowerCase()}`
+                        : 'auto-complete'
+                    ,
+                    value: term,
+                    ref: inputRef,
+                    size: size,
+                    prefix: prefix,
+                    suffix: suffix,
+                    placeholder: placeholder,
+                    onFocus: () => setIsFocused(true),
+                    onBlur: () => setIsFocused(false),
+                    onChange: (newValue: string) => {
+                        changeSearchTerm(newValue);
+                    },
+                    onKeyDown: (event: React.KeyboardEvent) => {
+                        switch (event.keyCode) {
+                            case EventKeyCodes.TAB:
+                            case EventKeyCodes.ENTER:
+                                event.preventDefault();
+                                event.stopPropagation();
+                                if (isFocused) {
+                                    // Unset initialTerm
+                                    resultsRef.current.clearInitialTerm();
+                                    // Set the active value of the autocomplete
+                                    resultsRef.current.selectActive();
+                                }
+                                break;
+                            case EventKeyCodes.ARROW_DOWN:
+                                event.preventDefault();
+                                event.stopPropagation();
+                                resultsRef.current.handleNext(term);
+                                break;
+                            case EventKeyCodes.ARROW_UP:
+                                event.preventDefault();
+                                event.stopPropagation();
+                                resultsRef.current.handlePrevious(term);
+                                break;
+                            default:
+                                if (resultsRef.current) {
+                                    resultsRef.current.clearInitialTerm();
+                                    resultsRef.current.setActiveIndex(0);
+                                }
+                                break;
+                        }
+                    },
+                    name: "auto-complete",
+                    className: "auto-complete-input",
+                })
+            }
+            {/* <Input
                 ariaLabel={
                     name.length
                         ? `auto-complete-${name.toLowerCase()}`
@@ -214,7 +267,7 @@ export const AutoComplete = ({
                 }}
                 name="auto-complete"
                 className="auto-complete-input"
-            />
+            /> */}
             {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer
                     size={size}

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
 // COMPONENTS
 import { Input } from '../Form';
+import { InputPropsType } from '../Form/Input/Input.component';
 import { ResultsContainer } from './ResultsContainer';
 
 const { useState, useRef } = React;
@@ -33,7 +34,7 @@ interface AutoCompleteProps {
     shadow?: boolean;
     // TODO: Allow children
     resultTemplate?: (props: any) => any;
-    inputComponent?: any;
+    inputProps?: InputPropsType;
     prefix?: any;
     suffix?: any;
     // Event Handlers
@@ -104,7 +105,7 @@ export const AutoComplete = ({
     color = 'text.light',
     dataSource = [],
     debug = false,
-    inputComponent = Input,
+    inputProps,
     name = '',
     onChange = () => null,
     onFilter = () => null,
@@ -165,30 +166,25 @@ export const AutoComplete = ({
             })}
             {...props}
         >
-            {/*
-                    This can render a custom input component and passed props. This custom input
-                    must be wrapped in forwardRef for this to work. Uses Input by default. Ex:
-
-                    const CustomInput = React.forwardRef(
-                        ({...props}) => <Input {...props} autoCapitalize="off" />
-                    );
-                */
-            React.createElement(inputComponent, {
-                ariaLabel: name.length
-                    ? `auto-complete-${name.toLowerCase()}`
-                    : 'auto-complete',
-                value: term,
-                ref: inputRef,
-                size: size,
-                prefix: prefix,
-                suffix: suffix,
-                placeholder: placeholder,
-                onFocus: () => setIsFocused(true),
-                onBlur: () => setIsFocused(false),
-                onChange: (newValue: string) => {
+            <Input
+                ariaLabel={
+                    name.length
+                        ? `auto-complete-${name.toLowerCase()}`
+                        : 'auto-complete'
+                }
+                inputProps={inputProps}
+                value={term}
+                ref={inputRef}
+                size={size}
+                prefix={prefix}
+                suffix={suffix}
+                placeholder={placeholder}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+                onChange={(newValue: string) => {
                     changeSearchTerm(newValue);
-                },
-                onKeyDown: (event: React.KeyboardEvent) => {
+                }}
+                onKeyDown={(event: React.KeyboardEvent) => {
                     switch (event.keyCode) {
                         case EventKeyCodes.TAB:
                         case EventKeyCodes.ENTER:
@@ -218,10 +214,10 @@ export const AutoComplete = ({
                             }
                             break;
                     }
-                },
-                name: 'auto-complete',
-                className: 'auto-complete-input',
-            })}
+                }}
+                name="auto-complete"
+                className="auto-complete-input"
+            />
 
             {(isFocused || debug) && dataSource.length > 0 && (
                 <ResultsContainer

--- a/src/AutoComplete/AutoComplete.stories.tsx
+++ b/src/AutoComplete/AutoComplete.stories.tsx
@@ -11,6 +11,7 @@ import { Search } from '../Icon';
 import { Item } from '../List';
 import { Typography } from '../Typography';
 import { RootTheme } from '../theme';
+import { Input } from '../Form/Input';
 // README
 import * as README from './README.md';
 // THEME
@@ -108,6 +109,8 @@ const StateBasedAutoCompleteStoryCustomResult = () => {
     );
 };
 
+const CustomInput = React.forwardRef(({...props}) => <Input {...props} autoCapitalize="off" />);
+
 storiesOf('Components/AutoComplete', module)
     .addParameters({
         readme: {
@@ -126,6 +129,7 @@ storiesOf('Components/AutoComplete', module)
                         <Typography tag="h1">AutoComplete 1</Typography>
                         <br />
                         <AutoComplete
+                            inputComponent={CustomInput}
                             debug={boolean('debug', false)}
                             allowClear={true}
                             placeholder="Search here..."

--- a/src/AutoComplete/AutoComplete.stories.tsx
+++ b/src/AutoComplete/AutoComplete.stories.tsx
@@ -11,7 +11,6 @@ import { Search } from '../Icon';
 import { Item } from '../List';
 import { Typography } from '../Typography';
 import { RootTheme } from '../theme';
-import { Input } from '../Form/Input';
 // README
 import * as README from './README.md';
 // THEME
@@ -109,8 +108,6 @@ const StateBasedAutoCompleteStoryCustomResult = () => {
     );
 };
 
-const CustomInput = React.forwardRef(({...props}) => <Input {...props} autoCapitalize="off" />);
-
 storiesOf('Components/AutoComplete', module)
     .addParameters({
         readme: {
@@ -129,7 +126,6 @@ storiesOf('Components/AutoComplete', module)
                         <Typography tag="h1">AutoComplete 1</Typography>
                         <br />
                         <AutoComplete
-                            inputComponent={CustomInput}
                             debug={boolean('debug', false)}
                             allowClear={true}
                             placeholder="Search here..."

--- a/src/Form/Input/Input.component.spec.tsx
+++ b/src/Form/Input/Input.component.spec.tsx
@@ -1,0 +1,91 @@
+// VENDOR
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { shallow, mount } from 'enzyme';
+import { ThemeProvider } from '@xstyled/styled-components';
+// COMPONENT
+import { Input } from './Input.component';
+import { RootTheme } from '../../theme';
+import {
+    ArrowBack as ArrowBackIcon,
+    ArrowForward as ArrowForwardIcon,
+} from '../../Icon';
+
+describe('Component: Form/Input', () => {
+    it('should be defined', () => {
+        const subject = (
+            <ThemeProvider theme={RootTheme}>
+                <Input />
+            </ThemeProvider>
+        );
+        const wrapper = mount(subject);
+        const component = shallow(subject);
+
+        expect(subject).toBeDefined();
+        expect(wrapper).toBeDefined();
+        expect(component).toBeDefined();
+        const tree = renderer.create(subject).toJSON();
+
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('should pass additional input attributes via inputProps', () => {
+        const subject = (
+            <ThemeProvider theme={RootTheme}>
+                <Input inputProps={{ autoCapitalize: 'false' }} />
+            </ThemeProvider>
+        );
+        const wrapper = mount(subject);
+
+        expect(wrapper.find({ autoCapitalize: 'false' })).toBeDefined();
+    });
+
+    it('should fire passed functions when events occur', () => {
+        let value = 0;
+        const changeValue = () => {
+            value++;
+        };
+        const changeMock = jest.fn();
+
+        const subject = (
+            <ThemeProvider theme={RootTheme}>
+                <Input
+                    onKeyDown={changeValue}
+                    onKeyUp={changeValue}
+                    onBlur={changeValue}
+                    onFocus={changeValue}
+                    onChange={changeMock}
+                    value="test"
+                />
+            </ThemeProvider>
+        );
+        const wrapper = mount(subject);
+        const input = wrapper.find('input');
+
+        input.simulate('keyDown');
+        expect(value).toBe(1);
+        input.simulate('keyUp');
+        expect(value).toBe(2);
+        input.simulate('blur');
+        expect(value).toBe(3);
+        input.simulate('focus');
+        expect(value).toBe(4);
+        input.simulate('change');
+        expect(changeMock.mock.calls[0][0]).toBe('test');
+    });
+
+    it('should render suffix and prefix JSX.', () => {
+        const subject = (
+            <ThemeProvider theme={RootTheme}>
+                <Input
+                    prefix={<ArrowForwardIcon />}
+                    suffix={<ArrowBackIcon />}
+                />
+            </ThemeProvider>
+        );
+        const wrapper = mount(subject);
+
+        expect(wrapper.find('anchor-icon.arrow-back')).toBeTruthy();
+        expect(wrapper.find('anchor-icon.arrow-forward')).toBeTruthy();
+    });
+});

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -301,6 +301,7 @@ export const Input = forwardRef(
                             value={inputValue}
                             type={type}
                             placeholder={placeholder}
+                            {...props}
                         />
                         {label && (
                             <Typography

--- a/src/Form/Input/Input.component.tsx
+++ b/src/Form/Input/Input.component.tsx
@@ -18,6 +18,10 @@ const {
     createRef,
 } = React;
 
+export type InputPropsType = {
+    [key: string]: string;
+};
+
 type InputTypes =
     // | 'button'
     // | 'checkbox'
@@ -50,26 +54,26 @@ type InputEventHandler = (
 
 interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
     // Identifiers
-    id?: string;
     className?: string;
+    id?: string;
     name?: string;
     // Value Assignment
     value?: InputContentType;
     // Presentation
+    ariaLabel?: string;
     autoFocus?: boolean;
     disabled?: boolean;
     // fullWidth?: boolean;
-    readOnly?: boolean;
-    placeholder?: string;
     label?: string;
-    ariaLabel?: string;
+    placeholder?: string;
+    readOnly?: boolean;
     // TODO: buttons?
     prefix?: any;
-    suffix?: any;
     size?: 'sm' | 'md' | 'lg';
+    suffix?: any;
     type?: InputTypes;
     // Overrides
-    inputProps?: any;
+    inputProps?: InputPropsType;
     // Event Handlers
     onChange?: InputEventHandler;
     onBlur?: InputEventHandler;
@@ -212,6 +216,7 @@ export const Input = forwardRef(
     (
         {
             className,
+            inputProps,
             onBlur = () => null,
             onKeyDown = () => null,
             onKeyUp = () => null,
@@ -301,6 +306,7 @@ export const Input = forwardRef(
                             value={inputValue}
                             type={type}
                             placeholder={placeholder}
+                            {...inputProps}
                             {...props}
                         />
                         {label && (

--- a/src/Form/Input/__snapshots__/Input.component.spec.tsx.snap
+++ b/src/Form/Input/__snapshots__/Input.component.spec.tsx.snap
@@ -1,0 +1,144 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: Form/Input should be defined 1`] = `
+.c0 {
+  display: block;
+  position: relative;
+  border: solid thin #D3D3D3;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  min-width: 5rem;
+  width: 100%;
+  margin: 0;
+  overflow: hidden;
+  height: 3.125rem;
+  padding: 0.25rem;
+}
+
+.c0::-webkit-input-placeholder {
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  color: #808080;
+}
+
+.c0::-moz-placeholder {
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  color: #808080;
+}
+
+.c0:-ms-input-placeholder {
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  color: #808080;
+}
+
+.c0::placeholder {
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  color: #808080;
+}
+
+.c0.focus {
+  border-color: #808080;
+}
+
+.c0 label {
+  -webkit-transform-origin: left bottom;
+  -ms-transform-origin: left bottom;
+  transform-origin: left bottom;
+  height: 1.4rem;
+  -webkit-transform: translate(0,0.6rem) scale(1);
+  -ms-transform: translate(0,0.6rem) scale(1);
+  transform: translate(0,0.6rem) scale(1);
+}
+
+.c0 label.lift {
+  -webkit-transform: translate(0,0) scale(1);
+  -ms-transform: translate(0,0) scale(1);
+  transform: translate(0,0) scale(1);
+}
+
+.c0 input {
+  height: 1rem;
+  font-size: 0.875rem;
+}
+
+.c2 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: column-reverse;
+  -ms-flex-flow: column-reverse;
+  flex-flow: column-reverse;
+  padding: 0 0.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c3 {
+  box-sizing: border-box;
+  border: none;
+  padding: 0;
+  outline: none !important;
+  touch-action: manipulation;
+  -webkit-appearance: none;
+  background-color: transparent;
+  z-index: 1;
+  color: #323232;
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+}
+
+.c3[type='number']::-webkit-inner-spin-button,
+.c3[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c3:placeholder-shown + label {
+  cursor: text;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+<div
+  className="c0 anchor-input"
+  onClick={[Function]}
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <input
+        className="c3"
+        name="input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        type="text"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/Grid/Grid/Grid.component.tsx
+++ b/src/Grid/Grid/Grid.component.tsx
@@ -88,10 +88,10 @@ export const Grid = ({
     rows,
     ...props
 }: GridProps) => {
+    const hasWindow = typeof window !== 'undefined' && window.innerWidth;
     const [innerWidth, setInnerWidth] = React.useState<number>(
-        window ? window.innerWidth : 0
+        hasWindow ? window.innerWidth : 0
     );
-    const hasWindow = window && window.innerWidth;
     // Default behavior is to use the breakpoints defined in the theme, but if the user doesn't use
     // the ThemeProvider it instead uses the breakpoints in the RootTheme.
     const { breakpoints: unsortedBreakpoints } =


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

* `AutoComplete` now passes through additional attributes to the `Input` component via the `inputProps` prop. 

* Fixes an issue with the doc site's build by being more explicit for checking for the existence of `window` in the `Grid` component.
