### PR TITLE
feat(Tooltip): upgrades, arrow and programatic show/hide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/DropDown/Arrow/Arrow.component.tsx
+++ b/src/DropDown/Arrow/Arrow.component.tsx
@@ -95,3 +95,4 @@ export const Arrow = styled('div')<ArrowProps>`
         return null;
     }}
 `;
+Arrow.displayName = 'Arrow';

--- a/src/Tooltip/Tooltip.component.spec.tsx
+++ b/src/Tooltip/Tooltip.component.spec.tsx
@@ -38,6 +38,41 @@ describe('Component: Tooltip', () => {
         wrapper.update();
         expect(wrapper.find(Tooltip).state().hidden).toBeTruthy();
     });
+    it("should force tooltip's visibility when show is set to true", () => {
+        const testSubject = (
+            <ThemeProvider theme={RootTheme}>
+                <Tooltip content="This is a tooltip" show={true}>
+                    <button>Hover</button>
+                </Tooltip>
+            </ThemeProvider>
+        );
+
+        const wrapper = mount(testSubject);
+
+        wrapper.simulate('mouseleave');
+        wrapper.update();
+
+        expect(
+            wrapper.find('.anchor-tooltip-element.active').exists()
+        ).toBeTruthy();
+    });
+    it('should show an arrow when showArrow is true.', () => {
+        const testSubject = (
+            <ThemeProvider theme={RootTheme}>
+                <Tooltip
+                    content="This is a tooltip"
+                    show={true}
+                    showArrow={true}
+                >
+                    <button>Hover</button>
+                </Tooltip>
+            </ThemeProvider>
+        );
+
+        const wrapper = mount(testSubject);
+
+        expect(wrapper.find('Arrow').exists()).toBeTruthy();
+    });
     it('should render all the different tooltip positions.', () => {
         [
             'topStart',

--- a/src/Tooltip/Tooltip.component.tsx
+++ b/src/Tooltip/Tooltip.component.tsx
@@ -17,7 +17,7 @@ interface TooltipContainerProps extends React.HTMLAttributes<HTMLDivElement> {
     display?: string;
     maxWidth?: string;
     position?: Position;
-    hidden?: boolean;
+    show?: boolean;
     shadow?: string;
     wrapContent?: boolean;
     // Arrow props
@@ -100,9 +100,10 @@ interface BackgroundProps {
 }
 
 const Background = styled('div')<BackgroundProps>`
-    ${({background}) => css({
-        background: th.color(background),
-    })}
+    ${({ background }) =>
+        css({
+            background: th.color(background),
+        })}
     position: absolute;
     left: 0;
     right: 0;
@@ -164,7 +165,7 @@ export class Tooltip extends React.Component<
             color,
             content,
             delay,
-            hidden : propsHidden,
+            show: propShow,
             maxWidth,
             position = 'topEnd',
             shadow,
@@ -175,19 +176,27 @@ export class Tooltip extends React.Component<
         const {
             height,
             width,
-            hidden : stateHidden,
+            hidden: stateHidden,
             toolTipHeight,
             toolTipWidth,
         } = this.state;
-        // If the dev passes hidden as a prop then Tooltip's behavior changes, and whether or not it
+        // If the dev passes show as a prop then Tooltip's behavior changes, and whether or not it
         // is visible is controlled by that prop and not by state.
-        const hiddenOveride = propsHidden !== undefined;
+        const hiddenOveride = propShow !== undefined;
 
         return (
             <ToolTipContainer
                 content={content}
-                onMouseEnter={hiddenOveride ? () => null : () => this.setState({ hidden: false })}
-                onMouseLeave={hiddenOveride ? () => null : () => this.setState({ hidden: true })}
+                onMouseEnter={
+                    hiddenOveride
+                        ? () => null
+                        : () => this.setState({ hidden: false })
+                }
+                onMouseLeave={
+                    hiddenOveride
+                        ? () => null
+                        : () => this.setState({ hidden: true })
+                }
                 ref={this.tooltipContainerRef}
                 className={classNames('anchor-tooltip', className)}
                 {...props}
@@ -196,7 +205,7 @@ export class Tooltip extends React.Component<
                 <TooltipElement
                     border={border}
                     className={classNames('anchor-tooltip-element', {
-                        active: hiddenOveride ? !propsHidden : !stateHidden,
+                        active: hiddenOveride ? propShow : !stateHidden,
                     })}
                     delay={delay}
                     ref={this.tooltipRef}
@@ -212,11 +221,9 @@ export class Tooltip extends React.Component<
                 >
                     <Background background={background} />
 
-                    <StyledContent>
-                        {content}
-                    </StyledContent>
+                    <StyledContent>{content}</StyledContent>
 
-                    {showArrow &&
+                    {showArrow && (
                         <Arrow
                             background={background}
                             border={border}
@@ -225,7 +232,7 @@ export class Tooltip extends React.Component<
                             shadow={shadow}
                             size={arrowSize}
                         />
-                    }
+                    )}
                 </TooltipElement>
             </ToolTipContainer>
         );

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -20,10 +20,17 @@ const StyledStory = styled('div')`
     padding: 2rem 5rem;
 `;
 
-const TooltipMessage = ({event}: any) => (
+const TooltipMessage = ({ event }: any) => (
     <div>
-        <Typography pb="3" pr="3">Hello there! Would you like this message to go away?</Typography>
-        <Button onClick={event} size="xs" variant="minimal" prefix={<Close color="red" />} />
+        <Typography pb="3" pr="3">
+            Hello there! Would you like this message to go away?
+        </Typography>
+        <Button
+            onClick={event}
+            size="xs"
+            variant="minimal"
+            prefix={<Close color="red" />}
+        />
     </div>
 );
 
@@ -63,6 +70,8 @@ storiesOf('Components/Tooltip', module)
                         delay={text('Tooltip delay', '') || undefined}
                         background={text('Tooltip background', '') || undefined}
                         showArrow={boolean('Show Arrow', false)}
+                        arrowIndent={text('Arrow Indent', '') || undefined}
+                        arrowSize={text('Arrow Size', '') || undefined}
                     >
                         <Button size="lg">Hover over me</Button>
                     </Tooltip>
@@ -71,32 +80,53 @@ storiesOf('Components/Tooltip', module)
         </StyledStory>
     ))
     .add('Arrows & JSX', () => {
-        const [hidden, setHidden] = React.useState(false);
+        const [show, setShow] = React.useState(true);
 
         return (
             <StyledStory>
                 <ThemeProvider theme={RootTheme}>
                     <Tooltip
-                        background="black"
-                        content={<TooltipMessage event={() => setHidden(!hidden)} />}
-                        hidden={hidden}
-                        position="bottomStart"
-                        showArrow
+                        background={text('Tooltip background', '#000')}
+                        content={
+                            <TooltipMessage event={() => setShow(!show)} />
+                        }
+                        position={select<Position>(
+                            'Tooltip Position',
+                            [
+                                'topStart',
+                                'top',
+                                'topEnd',
+                                'rightStart',
+                                'right',
+                                'rightEnd',
+                                'bottomEnd',
+                                'bottom',
+                                'bottomStart',
+                                'leftEnd',
+                                'left',
+                                'leftStart',
+                            ],
+                            'bottomStart'
+                        )}
+                        show={show}
+                        showArrow={boolean('Show Arrow', true)}
+                        arrowIndent={text('Arrow Indent', '') || undefined}
+                        arrowSize={text('Arrow Size', '') || undefined}
                         wrapContent={false}
                     >
                         <Typography tag="h2">
-                            Hovering does nothing. The Tooltip only goes away when the red button is
-                            clicked.
+                            Hovering does nothing. The Tooltip only goes away
+                            when the red x is clicked.
                         </Typography>
 
-                        {hidden &&
+                        {!show && (
                             <>
                                 <br />
-                                <Button onClick={() => setHidden(false)} size="sm">
+                                <Button onClick={() => setShow(true)} size="sm">
                                     Bring it Back!
                                 </Button>
                             </>
-                        }
+                        )}
                     </Tooltip>
                 </ThemeProvider>
             </StyledStory>

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -89,6 +89,8 @@ storiesOf('Components/Tooltip', module)
                         background={text('Tooltip background', '#000')}
                         content={
                             <TooltipMessage event={() => setShow(!show)} />
+                            // This rule is causing the build to fail, but lint insists on it
+                            // tslint:disable-next-line: jsx-curly-spacing
                         }
                         position={select<Position>(
                             'Tooltip Position',

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -10,6 +10,7 @@ import { Position } from '../utils/position/position';
 import { Tooltip } from './Tooltip.component';
 import { Button } from '../Button';
 import { Typography } from '../Typography';
+import { Close } from '../Icon';
 // README
 import * as README from './README.md';
 // THEME
@@ -18,6 +19,13 @@ import { RootTheme } from '../theme';
 const StyledStory = styled('div')`
     padding: 2rem 5rem;
 `;
+
+const TooltipMessage = ({event}: any) => (
+    <div>
+        <Typography pb="3" pr="3">Hello there! Would you like this message to go away?</Typography>
+        <Button onClick={event} size="xs" variant="minimal" prefix={<Close color="red" />} />
+    </div>
+);
 
 storiesOf('Components/Tooltip', module)
     .addParameters({
@@ -54,10 +62,43 @@ storiesOf('Components/Tooltip', module)
                         maxWidth={text('Tooltip width', 'auto')}
                         delay={text('Tooltip delay', '') || undefined}
                         background={text('Tooltip background', '') || undefined}
+                        showArrow={boolean('Show Arrow', false)}
                     >
                         <Button size="lg">Hover over me</Button>
                     </Tooltip>
                 </>
             </ThemeProvider>
         </StyledStory>
-    ));
+    ))
+    .add('Arrows & JSX', () => {
+        const [hidden, setHidden] = React.useState(false);
+
+        return (
+            <StyledStory>
+                <ThemeProvider theme={RootTheme}>
+                    <Tooltip
+                        background="black"
+                        content={<TooltipMessage event={() => setHidden(!hidden)} />}
+                        hidden={hidden}
+                        position="bottomStart"
+                        showArrow
+                        wrapContent={false}
+                    >
+                        <Typography tag="h2">
+                            Hovering does nothing. The Tooltip only goes away when the red button is
+                            clicked.
+                        </Typography>
+
+                        {hidden &&
+                            <>
+                                <br />
+                                <Button onClick={() => setHidden(false)} size="sm">
+                                    Bring it Back!
+                                </Button>
+                            </>
+                        }
+                    </Tooltip>
+                </ThemeProvider>
+            </StyledStory>
+        );
+    });

--- a/src/Tooltip/__snapshots__/Tooltip.component.spec.tsx.snap
+++ b/src/Tooltip/__snapshots__/Tooltip.component.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`Component: Tooltip should be defined and match its snapshot. 1`] = `
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -33,6 +32,22 @@ exports[`Component: Tooltip should be defined and match its snapshot. 1`] = `
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -47,7 +62,14 @@ exports[`Component: Tooltip should be defined and match its snapshot. 1`] = `
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -61,7 +83,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -85,6 +106,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -99,7 +136,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -113,7 +157,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 2
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -137,6 +180,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 2
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -151,7 +210,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 2
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -165,7 +231,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 3
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -189,6 +254,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 3
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -203,7 +284,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 3
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -217,7 +305,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 4
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -241,6 +328,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 4
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -255,7 +358,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 4
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -269,7 +379,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 5
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -293,6 +402,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 5
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -307,7 +432,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 5
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -321,7 +453,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 6
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -345,6 +476,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 6
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -359,7 +506,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 6
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -373,7 +527,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 7
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -397,6 +550,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 7
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -411,7 +580,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 7
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -425,7 +601,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 8
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -449,6 +624,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 8
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -463,7 +654,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 8
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -477,7 +675,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 9
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -501,6 +698,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 9
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -515,7 +728,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 9
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -529,7 +749,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -553,6 +772,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -567,7 +802,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -581,7 +823,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -605,6 +846,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -619,7 +876,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;
@@ -633,7 +897,6 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
 .c1 {
   position: absolute;
   box-sizing: border-box;
-  background: rgba(0,0,0,0.8);
   color: white;
   border-radius: 4px;
   font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
@@ -657,6 +920,22 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
   visibility: visible;
 }
 
+.c2 {
+  background: rgba(0,0,0,0.8);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.c3 {
+  z-index: 2;
+  position: relative;
+}
+
 <div
   className="c0 anchor-tooltip"
   content="This is a tooltip"
@@ -671,7 +950,14 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     height={0}
     width={0}
   >
-    This is a tooltip
+    <div
+      className="c2"
+    />
+    <div
+      className="c3"
+    >
+      This is a tooltip
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...

Adds the `Arrow` component from `DropDown` to tooltip and allows the user to override its default show/hide behavior by allowing them to pass a `hidden` prop which can be used to control it programatically.