### PR TITLE
chore: Exporting an interface needs a different name. Fixes tests in …

### DIFF
--- a/src/Icon/index.ts
+++ b/src/Icon/index.ts
@@ -1,6 +1,6 @@
 // When re-exporting an interface its type must be explicitly defined
-import { AnchorIcons } from './utils';
-export type AnchorIcons = AnchorIcons;
+import { AnchorIcons as AnchorIconsInterface } from './utils';
+export type AnchorIcons = AnchorIconsInterface;
 
 export { AddEvent } from './Icons/AddEvent.component';
 export { ArrowBack } from './Icons/ArrowBack.component';


### PR DESCRIPTION
…local dev.

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [ ] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Updates the interface export to be a different name. Otherwise this seems to break on newer versions of typescript due to the overloaded name.