### PR TITLE
fix: Cell now has default height and width of 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Grid/Cell/Cell.component.tsx
+++ b/src/Grid/Cell/Cell.component.tsx
@@ -70,13 +70,13 @@ export class Cell extends React.PureComponent<CellProps> {
         super(props, context);
 
         // Generates css data for xstyle'd media queries in the constructor so as to only
-        // fire a single time and before render.
+        // fire a single time and before render. Width and height have a default of 1.
         const { sortedResponsiveCSS, generalSettings } = generateBreakpointCSS(
             {
                 left: props.left,
-                height: props.height,
+                height: props.height || 1,
                 top: props.top,
-                width: props.width,
+                width: props.width || 1,
             },
             context.breakpoints,
             props.middle

--- a/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
+++ b/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
@@ -4,6 +4,8 @@ exports[`Component: Grid & Cell should be defined 1`] = `
 .c1 {
   height: 100%;
   min-width: 0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
   background-color: rgba(255,0,0,0.4);
 }
 
@@ -32,11 +34,15 @@ exports[`Component: Grid & Cell should be defined 1`] = `
 >
   <div
     className="c1 anchor-cell"
+    height={1}
+    width={1}
   >
     Cell 1
   </div>
   <div
     className="c1 anchor-cell"
+    height={1}
+    width={1}
   >
     Cell 2
   </div>


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
