### PR TITLE
docs(PopOver, Tooltip, DropDown, Grid, ResponsiveProvider): added PopOver, updated Tooltip, DropDown ResponsiveProvider, and Grid

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "author": "Kameron (@sharkparty), Steve (@zero0Halo)",
     "dependencies": {
         "@reach/component-component": "^0.1.3",
-        "@retailmenot/anchor": "^1.3.1",
+        "@retailmenot/anchor": "^1.3.3",
         "@xstyled/styled-components": "1.10.0",
         "@xstyled/system": "1.10.0",
         "algoliasearch": "^3.35.1",

--- a/docs/src/components/DropDownExample/MouseOverMe.component.tsx
+++ b/docs/src/components/DropDownExample/MouseOverMe.component.tsx
@@ -4,12 +4,11 @@
  * of code samples.
  */
 
-import * as React from 'react';
 import styled from '@xstyled/styled-components';
 import { Typography } from '@retailmenot/anchor';
 
 export const MouseOverMe = styled(Typography)`
-    background-color: accent.base;
+    background-color: accent.dark;
     width: 20rem;
     padding: 0.5rem 1rem;
 `;

--- a/docs/src/components/Utils/sections.ts
+++ b/docs/src/components/Utils/sections.ts
@@ -131,6 +131,13 @@ export const sections: Sections = [
                 presenting its own content area for the user to interact with. `,
             },
             {
+                title: 'PopOver',
+                path: '/components/popover/',
+                description: `The PopOver component is a targeted overlay, meaning its position is
+                determined by a piece of content that already exists on the page. Unlike Tooltip,
+                it is controlled programatically rather than by events.`,
+            },
+            {
                 title: 'Skeleton',
                 path: '/components/skeleton/',
                 description: `The Skeleton component is intended to show placeholder shapes while a

--- a/docs/src/pages/components/dropdown.mdx
+++ b/docs/src/pages/components/dropdown.mdx
@@ -151,6 +151,12 @@ together with `DropDown`!
         default: 'base',
     },
     {
+        property: 'debug',
+        description: `Forces the <pre>DropDown</pre>'s <pre>overlay</pre> to be visible
+            (useful for styling).`,
+        type: 'boolean',
+    },
+    {
         property: 'overlay',
         description: `The content that will be displayed when the child node is hovered
             over. This can be a single React element, or an array of React elements.`,

--- a/docs/src/pages/components/grid.mdx
+++ b/docs/src/pages/components/grid.mdx
@@ -37,12 +37,13 @@ with default settings.
 ## Responsive Usage
 
 The `Cell` props can accept an object with breakpoint data instead of a number. This allows you to
-set `left`, `height`, `top` and `width` values for any breakpoint set in `ResponsiveProvider`. As
+set `left`, `height`, `top` and `width` values for any breakpoint set in <Link to="/components/responsiveprovider">`ResponsiveProvider`</Link>. As
 noted above, this functionality only works if `ResponsiveProvider` is used. The breakpoints are
 mobile first.
 
-*NOTE: Unlike this example, it's best to put the `ResponsiveProvider` and `ThemeProvider` higher up
-in the application.*
+*NOTE: Cell uses the `breakpoint` data from `ResponsiveProvider` in order to generate media
+queries making them safe to use for SSR. Also, unlike in this example, it's best to put the
+`ResponsiveProvider` and `ThemeProvider` higher up in the application.*
 
 ```tsx live
 <ThemeProvider theme={RootTheme}>

--- a/docs/src/pages/components/popover.mdx
+++ b/docs/src/pages/components/popover.mdx
@@ -1,0 +1,165 @@
+import { PositionGrid } from './../../components/PositionGrid';
+import {
+    ApiTable,
+    ColorBlurb,
+    ComponentInfo,
+    FormatTypes
+} from '../../components/Utils';
+
+# PopOver
+
+<ComponentInfo title="PopOver" />
+
+<br />
+
+The `PopOver` has 12 possible placements via the `position` prop. These placements are based on the
+motion and direction of the content and less about exact positioning. The diagram below illustrates:
+
+<PositionGrid />
+
+```tsx live
+<Component initialState={{ showPopOver: true }}>
+    {
+        ({ state, setState }) => (
+            <PopOver
+                active={state.showPopOver}
+                content={<Typography tag="h3" color="gold" p="1">An Example PopOver</Typography>}
+                position="bottomStart"
+                shadow="5px 2px 2px rgba(0,0,0,0.25)"
+                showArrow={true}
+            >
+                <div>
+                    <Typography tag="h2" pb="2">
+                        PopOver Example
+                    </Typography>
+                    <Typography tag="p" pb="2">
+                        This is an example of a PopOver that uses a button to control its visibility.
+                    </Typography>
+                    <Button
+                        onClick={ () => {setState({showPopOver : !state.showPopOver})} }
+                        prefix={state.showPopOver ? <Heart /> : <HeartOutline />}
+                    />
+                </div>
+            </PopOver>
+        )
+    }
+</Component>
+```
+
+---
+
+## API
+
+<ApiTable data={[
+    {
+        property: 'active',
+        description: `Whether or not the <pre>PopOver</pre> is visible.`,
+        type: 'boolean',
+        default: false,
+    },
+    {
+        property: 'arrowIndent',
+        description: `How far the arrow should be indented relative to the <pre>PopOver</pre> content.
+            This setting works with all <pre>position</pre>'s
+            except <pre>bottom</pre>, <pre>top</pre>, <pre>right</pre> or <pre>left</pre>. Any valid
+            CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.75rem',
+    },
+    {
+        property: 'arrowSize',
+        description: `How large the arrow will be. Note that extremely large values will distort the
+            arrow. Any valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.625rem',
+    },
+    {
+        property: 'background',
+        description: <ColorBlurb label="PopOver" background gradient />,
+        type: 'string',
+        default: '#000000',
+    },
+    {
+        property: 'border',
+        description: `Displays a border around the <pre>PopOver</pre>, including the arrow
+            if <pre>showArrow</pre> is set to true. This accepts an valid CSS shorthand
+            for the <pre>border</pre> property.`,
+        type: 'string',
+    },
+    {
+        property: 'borderRadius',
+        description: `Controls the <pre>border-radius</pre> CSS property for the
+            <pre>PopOver</pre>. Any valid CSS for the <pre>border-radius</pre> CSS property is
+            allowed.`,
+        type: 'string',
+        default: '4px',
+    },
+    {
+        property: 'color',
+        description: <ColorBlurb label="PopOver" />,
+        type: 'string',
+        default: '#ffffff',
+    },
+    {
+        property: 'content',
+        description: 'The content of the <pre>PopOver</pre>.',
+        type: <FormatTypes data={['string', 'JSX']} noInterpret />,
+    },
+    {
+        property: 'delay',
+        description: `Delays the <pre>PopOver</pre>'s visibility change. Any valid
+            CSS <pre>transition-delay</pre> value is accepted.`,
+        type: 'string',
+    },
+    {
+        property: 'debug',
+        description: `Forces the <pre>PopOver</pre>'s <pre>content</pre> to be visible regardless of
+            the <pre>active</pre> prop.`,
+        type: 'boolean',
+    },
+    {
+        property: 'maxWidth',
+        description: `Property for the maximum width of the <pre>PopOver</pre>.`,
+        type: 'string',
+        default: 'auto',
+    },
+    {
+        property: 'position',
+        description: `Where the <pre>PopOver</pre> should appear when <pre>active</pre> is true.`,
+        type: <FormatTypes
+                data={[
+                    'topStart',
+                    'top',
+                    'topEnd',
+                    'rightStart',
+                    'right',
+                    'rightEnd',
+                    'bottomEnd',
+                    'bottom',
+                    'bottomStart',
+                    'leftEnd',
+                    'left',
+                    'leftStart',
+                ]} />,
+        default: 'topEnd',
+    },
+    {
+        property: 'shadow',
+        description: `The dropshadow that appears beneath the <pre>PopOver</pre>. This accepts any
+            valid CSS <pre>box-shadow</pre> values.`,
+        type: 'string',
+    },
+    {
+        property: 'showArrow',
+        description: `Whether or not the arrow should be displayed.`,
+        type: 'boolean',
+        default: 'true',
+    },
+    {
+        property: 'spacing',
+        description: `The distance the <pre>PopOver</pre> will be from the contained element. Any
+            valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.75rem',
+    },
+]}/>

--- a/docs/src/pages/components/responsiveprovider.mdx
+++ b/docs/src/pages/components/responsiveprovider.mdx
@@ -3,6 +3,7 @@ import {
     ComponentInfo,
     FormatTypes
 } from '../../components/Utils';
+import { Link } from 'gatsby';
 import { ResponsiveContextExample } from '../../components/ResponsiveContextExample';
 
 # ResponsiveProvider
@@ -152,6 +153,23 @@ And here's the result:
 <ResponsiveContextExample />
 
 <br />
+
+---
+
+## A Note About Server Side Rendering (SSR)
+
+It's important to remember that when using the `ResponsiveProvider`, that it can never return an
+accurate value for `innerWidth` or `current` with SSR on an initial render. These values require a
+`window` object to exist, and SSR pages do not have a `window` object upon their initial render.
+However, the `breakpoints` value does not depend on the `window` object as its primary function is to
+sort the `breakpoints` values in the `ThemeProvider`.
+
+`innerWidth` and `current` are most useful for client side rendering, particularly in situations
+where it's helpful to place content that needs to appear based on user interaction.
+
+All **Anchor** components are built with SSR in mind so you should feel safe using them.
+For example, the <Link to="/components/grid">`Grid` and `Cell`</Link> components are built using
+`breakpoints` expressly to avoid SSR issues.
 
 ---
 

--- a/docs/src/pages/components/tooltip.mdx
+++ b/docs/src/pages/components/tooltip.mdx
@@ -22,8 +22,9 @@ motion and direction of the content and less about exact positioning. The diagra
     content="Here is some lovely content."
     display="inline-block"
     maxWidth="10rem"
-    position="right"
+    position="bottomStart"
     wrap="true"
+    showArrow={true}
 >
     <Button>Hover over me</Button>
 </Tooltip>
@@ -34,6 +35,22 @@ motion and direction of the content and less about exact positioning. The diagra
 ## API
 
 <ApiTable data={[
+    {
+        property: 'arrowIndent',
+        description: `How far the arrow should be indented relative to the <pre>Tooltip</pre> content.
+            This setting works with all <pre>position</pre>'s
+            except <pre>bottom</pre>, <pre>top</pre>, <pre>right</pre> or <pre>left</pre>. Any valid
+            CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.75rem',
+    },
+    {
+        property: 'arrowSize',
+        description: `How large the arrow will be. Note that extremely large values will distort the
+            arrow. Any valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.625rem',
+    },
     {
         property: 'background',
         description: <ColorBlurb label="Tooltip" background gradient />,
@@ -50,6 +67,17 @@ motion and direction of the content and less about exact positioning. The diagra
         property: 'content',
         description: 'The text that will appear in the <pre>Tooltip</pre>.',
         type: 'string',
+    },
+    {
+        property: 'delay',
+        description: `Delays the <pre>Tooltip</pre>'s visibility change. Any valid
+            CSS <pre>transition-delay</pre> value is accepted.`,
+        type: 'string',
+    },
+    {
+        property: 'debug',
+        description: `Forces the <pre>Tooltip</pre> to be visible (useful for styling).`,
+        type: 'boolean',
     },
     {
         property: 'display',
@@ -82,6 +110,19 @@ motion and direction of the content and less about exact positioning. The diagra
                     'leftStart',
                 ]} />,
         default: 'topEnd',
+    },
+    {
+        property: 'showArrow',
+        description: `Whether or not the arrow should be displayed.`,
+        type: 'boolean',
+        default: 'true',
+    },
+    {
+        property: 'spacing',
+        description: `The distance the <pre>Tooltip</pre> will be from the contained element. Any
+            valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
+        type: 'string',
+        default: '0.75rem',
     },
     {
         property: 'wrap',


### PR DESCRIPTION
docs(PopOver): added

docs(DropDown): updated api with debug prop

docs(Tooltip): updated api with arrowIndent, arrowSize, delay, debug, showArrow and spacing

style(MouseOverMe): changed background-color of the typography to be accent.dark

docs(responsive): added notes about SSR for both Grid and ResponsiveProvider

chore: bumped anchor module to v1.3.3

docs(ResponsiveProvider): small grammar changes to SSR section

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

* Adds documentation for `PopOver` components
* Adds additional prop information for `DropDown` and `Tooltip`.
* Adds a section on SSR to `ResponsiveProvider`
* Updates `Grid` with a note on SSR.

