### PR TITLE
docs: fixed the spacing prop description/default for PopOver and Tooltip

### DIFF
--- a/docs/src/pages/components/popover.mdx
+++ b/docs/src/pages/components/popover.mdx
@@ -157,9 +157,9 @@ motion and direction of the content and less about exact positioning. The diagra
     },
     {
         property: 'spacing',
-        description: `The distance the <pre>PopOver</pre> will be from the contained element. Any
-            valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
-        type: 'string',
-        default: '0.75rem',
+        description: `The distance in <pre>px</pre> the <pre>PopOver</pre> will be from the
+            contained element.`,
+        type: 'number',
+        default: '8',
     },
 ]}/>

--- a/docs/src/pages/components/tooltip.mdx
+++ b/docs/src/pages/components/tooltip.mdx
@@ -119,10 +119,10 @@ motion and direction of the content and less about exact positioning. The diagra
     },
     {
         property: 'spacing',
-        description: `The distance the <pre>Tooltip</pre> will be from the contained element. Any
-            valid CSS unit (<pre>em</pre>, <pre>px</pre>, etc.) is accepted.`,
-        type: 'string',
-        default: '0.75rem',
+        description: `The distance in <pre>px</pre> the <pre>Tooltip</pre> will be from the
+            contained element.`,
+        type: 'number',
+        default: '8',
     },
     {
         property: 'wrap',


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
