### PR TITLE
feat(Cell): add spacing styled props, alignment options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Grid/Cell/Cell.component.tsx
+++ b/src/Grid/Cell/Cell.component.tsx
@@ -25,6 +25,10 @@ interface CellProps extends SpaceProps {
     top?: GridSetting;
     valign?: string;
     width?: GridSetting;
+
+    // These should be deprecated in favor of align and valign
+    center?: boolean;
+    middle?: boolean;
 }
 
 const StyledCell = styled.div<CellProps>`
@@ -57,6 +61,8 @@ const StyledCell = styled.div<CellProps>`
 
 interface BoxProps extends SpaceProps {
     align?: string;
+    center?: boolean;
+    middle?: boolean;
     valign?: string;
 }
 
@@ -74,37 +80,48 @@ const Box = styled('div')<BoxProps>`
 
     ${spaceStyles}
 
-    ${({align, valign}) => {
+    ${({ align, center, middle, valign }) => {
         const styles: BoxStyles = {};
+        // This is to keep the API from breaking from v1.3.3 and below.
+        // The middle and center props should be deprecated.
+        const tmpValign = middle ? 'middle' : valign;
+        const tmpAlign = center ? 'center' : align;
 
-        if (align || valign) {
+        if (tmpAlign || tmpValign) {
             styles.display = 'flex';
 
-            if (valign) {
+            if (tmpValign) {
                 styles.height = '100%';
             }
         }
 
-        switch (align) {
+        switch (tmpAlign) {
             case 'left':
-                styles.justifyContent = 'flex-start'; break;
+                styles.justifyContent = 'flex-start';
+                break;
             case 'center':
-                styles.justifyContent = 'center'; break;
+                styles.justifyContent = 'center';
+                break;
             case 'right':
-                styles.justifyContent = 'flex-end'; break;
+                styles.justifyContent = 'flex-end';
+                break;
         }
 
-        switch (valign) {
+        switch (tmpValign) {
             case 'top':
-                styles.alignItems = 'flex-start'; break;
+                styles.alignItems = 'flex-start';
+                break;
             case 'middle':
-                styles.alignItems = 'center'; break;
+                styles.alignItems = 'center';
+                break;
             case 'bottom':
-                styles.alignItems = 'flex-end'; break;
+                styles.alignItems = 'flex-end';
+                break;
         }
         return css(styles);
     }}
 `;
+Box.displayName = 'Box';
 
 interface CellState {
     generalSettings: GridSettings;
@@ -136,7 +153,15 @@ export class Cell extends React.PureComponent<CellProps> {
     }
 
     render() {
-        const { align, children, className, debug, valign } = this.props;
+        const {
+            align,
+            center,
+            children,
+            className,
+            debug,
+            middle,
+            valign,
+        } = this.props;
         const { generalSettings, sortedResponsiveCSS } = this.state;
 
         return (
@@ -151,8 +176,15 @@ export class Cell extends React.PureComponent<CellProps> {
                         top={generalSettings.top || undefined}
                         width={generalSettings.width || undefined}
                     >
-                        {/* The spread ensures the spaceStyles get applied to Box */}
-                        <Box {...this.props} align={align} valign={valign}>
+                        {/* The spread ensures that spaceStyles get applied to Box and NOT StyledCell */}
+                        <Box
+                            {...this.props}
+                            align={align}
+                            center={center}
+                            className="anchor-cell-box"
+                            valign={valign}
+                            middle={middle}
+                        >
                             {children}
                         </Box>
                     </StyledCell>

--- a/src/Grid/Cell/Cell.component.tsx
+++ b/src/Grid/Cell/Cell.component.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled, { css } from '@xstyled/styled-components';
-import { breakpoints } from '@xstyled/system';
+import { breakpoints, space as spaceStyles, SpaceProps } from '@xstyled/system';
 import classNames from 'classnames';
 import {
     BreakpointType,
@@ -14,7 +14,7 @@ import {
 import { ResponsiveContext } from '../ResponsiveProvider';
 import { ResponsiveContextProps } from '../ResponsiveProvider/ResponsiveProvider.component';
 
-interface CellProps {
+interface CellProps extends SpaceProps {
     area?: string;
     center?: boolean;
     children?: any;
@@ -56,6 +56,12 @@ const StyledCell = styled.div<CellProps>`
         css({
             backgroundColor: debugColor,
         })};
+
+    ${spaceStyles}
+`;
+
+const Box = styled('div')<SpaceProps>`
+    ${spaceStyles}
 `;
 
 interface CellState {
@@ -107,7 +113,7 @@ export class Cell extends React.PureComponent<CellProps> {
                         top={generalSettings.top || undefined}
                         width={generalSettings.width || undefined}
                     >
-                        {children}
+                        <Box {...this.props}>{children}</Box>
                     </StyledCell>
                 )}
             </GridContext.Consumer>

--- a/src/Grid/Grid/Grid.component.spec.tsx
+++ b/src/Grid/Grid/Grid.component.spec.tsx
@@ -45,7 +45,7 @@ describe('Component: Grid & Cell', () => {
 });
 
 describe('Component: Cell', () => {
-    it('should align content vertically', () => {
+    it('should align content horizontally', () => {
         const valignOptions = ['top', 'middle', 'bottom'];
 
         valignOptions.map(option => {

--- a/src/Grid/Grid/Grid.component.spec.tsx
+++ b/src/Grid/Grid/Grid.component.spec.tsx
@@ -44,6 +44,40 @@ describe('Component: Grid & Cell', () => {
     });
 });
 
+describe('Component: Cell', () => {
+    it('should align content vertically', () => {
+        const valignOptions = ['top', 'middle', 'bottom'];
+
+        valignOptions.map(option => {
+            const testSubject = (
+                <ThemeProvider theme={RootTheme}>
+                    <Grid>
+                        <Cell valign={option}>Text</Cell>
+                    </Grid>
+                </ThemeProvider>
+            );
+            const tree = renderer.create(testSubject).toJSON();
+            expect(tree).toMatchSnapshot();
+        });
+    });
+
+    it('should align content vertically', () => {
+        const alignOptions = ['left', 'center', 'right'];
+
+        alignOptions.map(option => {
+            const testSubject = (
+                <ThemeProvider theme={RootTheme}>
+                    <Grid>
+                        <Cell align={option}>Text</Cell>
+                    </Grid>
+                </ThemeProvider>
+            );
+            const tree = renderer.create(testSubject).toJSON();
+            expect(tree).toMatchSnapshot();
+        });
+    });
+});
+
 describe('Utilities: Grid & Cell', () => {
     const testObject = { xs: 0, md: 900, sm: 600 };
     const innerWidth = 780;
@@ -68,10 +102,7 @@ describe('Utilities: Grid & Cell', () => {
             left: 1,
             height: { xs: 3, md: 1 },
         };
-        const value = generateBreakpointCSS(
-            gridSettings,
-            sortedBreakpoints
-        );
+        const value = generateBreakpointCSS(gridSettings, sortedBreakpoints);
 
         expect(value.sortedResponsiveCSS.length).toBe(2);
         expect(Object.keys(value.generalSettings)[0]).toBe('left');

--- a/src/Grid/Grid/Grid.component.spec.tsx
+++ b/src/Grid/Grid/Grid.component.spec.tsx
@@ -68,11 +68,9 @@ describe('Utilities: Grid & Cell', () => {
             left: 1,
             height: { xs: 3, md: 1 },
         };
-        const middle = true;
         const value = generateBreakpointCSS(
             gridSettings,
-            sortedBreakpoints,
-            middle
+            sortedBreakpoints
         );
 
         expect(value.sortedResponsiveCSS.length).toBe(2);

--- a/src/Grid/Grid/Grid.component.tsx
+++ b/src/Grid/Grid/Grid.component.tsx
@@ -1,9 +1,11 @@
 // VENDOR
 import * as React from 'react';
 import styled, { css } from '@xstyled/styled-components';
+import { space as spaceStyles, SpaceProps } from '@xstyled/system';
 import classNames from 'classnames';
 // COMPONENTS & UTILS
 import { debugColor, FLOW, GridContext } from '../utils';
+import { Cell } from '../Cell';
 
 type Flow = keyof typeof FLOW;
 
@@ -48,7 +50,7 @@ type AlignContent =
     | 'unsafe center'
     | 'unset';
 
-interface GridProps {
+interface GridProps extends SpaceProps {
     alignContent?: AlignContent;
     areas?: string[];
     children?: any;
@@ -100,6 +102,8 @@ const StyledGrid = styled('div')<GridProps>`
         ${alignContent && `align-content: ${alignContent}`};
         ${debug && `background-color: ${debugColor}`};
     `}
+
+    ${spaceStyles}
 `;
 
 export const Grid = ({
@@ -135,3 +139,5 @@ export const Grid = ({
         </GridContext.Provider>
     </StyledGrid>
 );
+
+Grid.Cell = Cell;

--- a/src/Grid/Grid/Grid.stories.tsx
+++ b/src/Grid/Grid/Grid.stories.tsx
@@ -2,10 +2,11 @@
 import * as React from 'react';
 import styled from '@xstyled/styled-components';
 import { storiesOf } from '@storybook/react';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, radios, select } from '@storybook/addon-knobs';
 import { ThemeProvider } from '@xstyled/styled-components';
 // COMPONENTS
 import { Typography } from '../../Typography';
+import { Button } from '../../Button';
 import { Grid, ResponsiveProvider } from '../index';
 import { FLOW } from '../utils';
 import { RootTheme } from '../../theme';
@@ -32,8 +33,8 @@ storiesOf('Components/Grid', module)
                         m={3}
                     >
                         <Cell
-                            center
-                            middle
+                            align="center"
+                            valign="middle"
                             height={{ md: 2, lg: 3 }}
                             width={{ xs: 0, md: 12 }}
                         >
@@ -42,8 +43,14 @@ storiesOf('Components/Grid', module)
                         <Cell width={{ xs: 12, md: 6 }}>
                             <Typography>Cell 1</Typography>
                         </Cell>
-                        <Cell width={{ xs: 12, md: 6 }} pt={3} center>
-                            <Typography>Cell 2</Typography>
+                        <Cell
+                            align={radios('Align', { left: 'left', center: 'center', right: 'right' }, 'left')}
+                            valign={radios('Valign', { top: 'top', middle: 'middle', bottom: 'bottom' }, 'top')}
+                            p={select('Padding', [0, 1, 2, 3, 4], 0)}
+                            height={4}
+                            width={{ xs: 12, md: 6 }}
+                        >
+                            <Button>Align Me!</Button>
                         </Cell>
                         <Cell width={{ xs: 12, md: 6 }} left={{ xs: 1, md: 4 }}>
                             <Typography>Cell 3</Typography>
@@ -62,7 +69,7 @@ storiesOf('Components/Grid', module)
                         debug={boolean('Grid Debug', true)}
                         rows={'minmax(3rem,auto) 1fr minmax(3rem,auto)'}
                     >
-                        <Cell center middle width={3}>
+                        <Cell width={3} align="center" valign="middle">
                             <Typography tag="h1">Header</Typography>
                         </Cell>
 
@@ -76,7 +83,7 @@ storiesOf('Components/Grid', module)
                             <Typography>Ads</Typography>
                         </Cell>
 
-                        <Cell center middle width={3}>
+                        <Cell width={3} align="center" valign="middle">
                             <Typography tag="h2">Footer</Typography>
                         </Cell>
                     </StoryGrid>

--- a/src/Grid/Grid/Grid.stories.tsx
+++ b/src/Grid/Grid/Grid.stories.tsx
@@ -6,9 +6,11 @@ import { boolean } from '@storybook/addon-knobs';
 import { ThemeProvider } from '@xstyled/styled-components';
 // COMPONENTS
 import { Typography } from '../../Typography';
-import { Cell, Grid, ResponsiveProvider } from '../index';
+import { Grid, ResponsiveProvider } from '../index';
 import { FLOW } from '../utils';
 import { RootTheme } from '../../theme';
+
+const { Cell } = Grid;
 
 const StoryGrid = styled(Grid)`
     height: 100vh;
@@ -23,7 +25,12 @@ storiesOf('Components/Grid', module)
                     debug={boolean('ResponsiveProvider Debug', true)}
                 >
                     <br />
-                    <Grid flow={FLOW.row} debug={boolean('Grid Debug', true)}>
+                    <Grid
+                        flow={FLOW.row}
+                        debug={boolean('Grid Debug', true)}
+                        p={1}
+                        m={3}
+                    >
                         <Cell
                             center
                             middle
@@ -35,7 +42,7 @@ storiesOf('Components/Grid', module)
                         <Cell width={{ xs: 12, md: 6 }}>
                             <Typography>Cell 1</Typography>
                         </Cell>
-                        <Cell width={{ xs: 12, md: 6 }}>
+                        <Cell width={{ xs: 12, md: 6 }} pt={3} center>
                             <Typography>Cell 2</Typography>
                         </Cell>
                         <Cell width={{ xs: 12, md: 6 }} left={{ xs: 1, md: 4 }}>

--- a/src/Grid/Grid/Grid.stories.tsx
+++ b/src/Grid/Grid/Grid.stories.tsx
@@ -44,8 +44,24 @@ storiesOf('Components/Grid', module)
                             <Typography>Cell 1</Typography>
                         </Cell>
                         <Cell
-                            align={radios('Align', { left: 'left', center: 'center', right: 'right' }, 'left')}
-                            valign={radios('Valign', { top: 'top', middle: 'middle', bottom: 'bottom' }, 'top')}
+                            align={radios(
+                                'Align',
+                                {
+                                    left: 'left',
+                                    center: 'center',
+                                    right: 'right',
+                                },
+                                'left'
+                            )}
+                            valign={radios(
+                                'Valign',
+                                {
+                                    top: 'top',
+                                    middle: 'middle',
+                                    bottom: 'bottom',
+                                },
+                                'top'
+                            )}
                             p={select('Padding', [0, 1, 2, 3, 4], 0)}
                             height={4}
                             width={{ xs: 12, md: 6 }}

--- a/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
+++ b/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
@@ -1,5 +1,284 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: Cell should align content vertically 1`] = `
+.c1 {
+  height: 100%;
+  min-width: 0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c0 {
+  display: grid;
+  height: auto;
+  grid-auto-flow: row;
+  grid-auto-rows: minmax(1.25rem,auto);
+  grid-template-columns: repeat(12,1fr);
+  grid-gap: 0.5rem;
+}
+
+<div
+  className="c0 anchor-grid"
+>
+  <div
+    className="c1 anchor-cell"
+    height={1}
+    width={1}
+  >
+    <div
+      className="c2 anchor-cell-box"
+    >
+      Text
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Component: Cell should align content vertically 2`] = `
+.c1 {
+  height: 100%;
+  min-width: 0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 {
+  display: grid;
+  height: auto;
+  grid-auto-flow: row;
+  grid-auto-rows: minmax(1.25rem,auto);
+  grid-template-columns: repeat(12,1fr);
+  grid-gap: 0.5rem;
+}
+
+<div
+  className="c0 anchor-grid"
+>
+  <div
+    className="c1 anchor-cell"
+    height={1}
+    width={1}
+  >
+    <div
+      className="c2 anchor-cell-box"
+    >
+      Text
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Component: Cell should align content vertically 3`] = `
+.c1 {
+  height: 100%;
+  min-width: 0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c0 {
+  display: grid;
+  height: auto;
+  grid-auto-flow: row;
+  grid-auto-rows: minmax(1.25rem,auto);
+  grid-template-columns: repeat(12,1fr);
+  grid-gap: 0.5rem;
+}
+
+<div
+  className="c0 anchor-grid"
+>
+  <div
+    className="c1 anchor-cell"
+    height={1}
+    width={1}
+  >
+    <div
+      className="c2 anchor-cell-box"
+    >
+      Text
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Component: Cell should align content vertically 4`] = `
+.c1 {
+  height: 100%;
+  min-width: 0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c0 {
+  display: grid;
+  height: auto;
+  grid-auto-flow: row;
+  grid-auto-rows: minmax(1.25rem,auto);
+  grid-template-columns: repeat(12,1fr);
+  grid-gap: 0.5rem;
+}
+
+<div
+  className="c0 anchor-grid"
+>
+  <div
+    className="c1 anchor-cell"
+    height={1}
+    width={1}
+  >
+    <div
+      className="c2 anchor-cell-box"
+    >
+      Text
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Component: Cell should align content vertically 5`] = `
+.c1 {
+  height: 100%;
+  min-width: 0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  display: grid;
+  height: auto;
+  grid-auto-flow: row;
+  grid-auto-rows: minmax(1.25rem,auto);
+  grid-template-columns: repeat(12,1fr);
+  grid-gap: 0.5rem;
+}
+
+<div
+  className="c0 anchor-grid"
+>
+  <div
+    className="c1 anchor-cell"
+    height={1}
+    width={1}
+  >
+    <div
+      className="c2 anchor-cell-box"
+    >
+      Text
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Component: Cell should align content vertically 6`] = `
+.c1 {
+  height: 100%;
+  min-width: 0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c0 {
+  display: grid;
+  height: auto;
+  grid-auto-flow: row;
+  grid-auto-rows: minmax(1.25rem,auto);
+  grid-template-columns: repeat(12,1fr);
+  grid-gap: 0.5rem;
+}
+
+<div
+  className="c0 anchor-grid"
+>
+  <div
+    className="c1 anchor-cell"
+    height={1}
+    width={1}
+  >
+    <div
+      className="c2 anchor-cell-box"
+    >
+      Text
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Component: Grid & Cell should be defined 1`] = `
 .c1 {
   height: 100%;
@@ -7,6 +286,10 @@ exports[`Component: Grid & Cell should be defined 1`] = `
   grid-column-end: span 1;
   grid-row-end: span 1;
   background-color: rgba(255,0,0,0.4);
+}
+
+.c2 {
+  box-sizing: border-box;
 }
 
 .c0 {
@@ -38,7 +321,7 @@ exports[`Component: Grid & Cell should be defined 1`] = `
     width={1}
   >
     <div
-      className=""
+      className="c2 anchor-cell-box"
     >
       Cell 1
     </div>
@@ -49,7 +332,7 @@ exports[`Component: Grid & Cell should be defined 1`] = `
     width={1}
   >
     <div
-      className=""
+      className="c2 anchor-cell-box"
     >
       Cell 2
     </div>

--- a/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
+++ b/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: Cell should align content vertically 1`] = `
+exports[`Component: Cell should align content horizontally 1`] = `
 .c1 {
   height: 100%;
   min-width: 0;
@@ -47,7 +47,7 @@ exports[`Component: Cell should align content vertically 1`] = `
 </div>
 `;
 
-exports[`Component: Cell should align content vertically 2`] = `
+exports[`Component: Cell should align content horizontally 2`] = `
 .c1 {
   height: 100%;
   min-width: 0;
@@ -94,7 +94,7 @@ exports[`Component: Cell should align content vertically 2`] = `
 </div>
 `;
 
-exports[`Component: Cell should align content vertically 3`] = `
+exports[`Component: Cell should align content horizontally 3`] = `
 .c1 {
   height: 100%;
   min-width: 0;
@@ -141,7 +141,7 @@ exports[`Component: Cell should align content vertically 3`] = `
 </div>
 `;
 
-exports[`Component: Cell should align content vertically 4`] = `
+exports[`Component: Cell should align content vertically 1`] = `
 .c1 {
   height: 100%;
   min-width: 0;
@@ -187,7 +187,7 @@ exports[`Component: Cell should align content vertically 4`] = `
 </div>
 `;
 
-exports[`Component: Cell should align content vertically 5`] = `
+exports[`Component: Cell should align content vertically 2`] = `
 .c1 {
   height: 100%;
   min-width: 0;
@@ -233,7 +233,7 @@ exports[`Component: Cell should align content vertically 5`] = `
 </div>
 `;
 
-exports[`Component: Cell should align content vertically 6`] = `
+exports[`Component: Cell should align content vertically 3`] = `
 .c1 {
   height: 100%;
   min-width: 0;

--- a/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
+++ b/src/Grid/Grid/__snapshots__/Grid.component.spec.tsx.snap
@@ -37,14 +37,22 @@ exports[`Component: Grid & Cell should be defined 1`] = `
     height={1}
     width={1}
   >
-    Cell 1
+    <div
+      className=""
+    >
+      Cell 1
+    </div>
   </div>
   <div
     className="c1 anchor-cell"
     height={1}
     width={1}
   >
-    Cell 2
+    <div
+      className=""
+    >
+      Cell 2
+    </div>
   </div>
 </div>
 `;

--- a/src/Grid/index.ts
+++ b/src/Grid/index.ts
@@ -1,5 +1,7 @@
 export { ResponsiveContext, ResponsiveProvider } from './ResponsiveProvider';
 
+// TODO: Cell ships both as a standalone component but also as a child of Grid. At a later release
+// (current is 1.3.4) the standalone version should be deprecated.
 export { Cell } from '../Grid/Cell';
 export { Grid } from '../Grid/Grid';
 

--- a/src/Grid/utils.ts
+++ b/src/Grid/utils.ts
@@ -88,8 +88,8 @@ const ops = {
     // If width is 0, don't show the cell. If middle is true, add in the middle CSS.
     width: (width: any, middle: boolean) =>
         width > 0
-        ? `grid-column-end: span ${width}; display: block;`
-        : 'display: none;',
+            ? `grid-column-end: span ${width}; display: block;`
+            : 'display: none;',
     height: (height: any) => `grid-row-end: span ${height};`,
     left: (left: any) => `grid-column-start: ${left};`,
     top: (top: any) => `grid-row-start: ${top};`,
@@ -132,7 +132,9 @@ export function generateBreakpointCSS(
                         if (!responsiveCSS[breakpointKey]) {
                             responsiveCSS[breakpointKey] = '';
                         }
-                        responsiveCSS[breakpointKey] += ops[gridSettingKey](responsiveValue);
+                        responsiveCSS[breakpointKey] += ops[gridSettingKey](
+                            responsiveValue
+                        );
                     }
                 }
             }

--- a/src/Grid/utils.ts
+++ b/src/Grid/utils.ts
@@ -4,7 +4,6 @@
 */
 
 import { createContext } from 'react';
-import { css } from '@xstyled/styled-components';
 
 export type BreakpointType = {
     [key: string]: number;
@@ -82,16 +81,6 @@ export function getBreakpointKey(
 }
 
 /*
-    CSS used both by generateBreakpointCSS() and the Cell component. Aligns content vertically.
-*/
-export const middleCSS = css`
-    display: inline-flex;
-    flex-flow: column wrap;
-    justify-content: center;
-    justify-self: stretch;
-`;
-
-/*
     Small helper object for the generateBreakpointCSS() function to render the correct CSS for each
     grid setting.
 */
@@ -99,10 +88,8 @@ const ops = {
     // If width is 0, don't show the cell. If middle is true, add in the middle CSS.
     width: (width: any, middle: boolean) =>
         width > 0
-            ? middle
-                ? `grid-column-end: span ${width}; ${middleCSS}`
-                : `grid-column-end: span ${width}; display: block;`
-            : 'display:none;',
+        ? `grid-column-end: span ${width}; display: block;`
+        : 'display: none;',
     height: (height: any) => `grid-row-end: span ${height};`,
     left: (left: any) => `grid-column-start: ${left};`,
     top: (top: any) => `grid-row-start: ${top};`,
@@ -117,8 +104,7 @@ const ops = {
 */
 export function generateBreakpointCSS(
     gridSettings: GridSettings,
-    sortedBreakpoints: BreakpointType[],
-    middle: boolean | undefined
+    sortedBreakpoints: BreakpointType[]
 ) {
     const responsiveCSS = {};
     const sortedResponsiveCSS: BreakpointType[] = [];
@@ -146,10 +132,7 @@ export function generateBreakpointCSS(
                         if (!responsiveCSS[breakpointKey]) {
                             responsiveCSS[breakpointKey] = '';
                         }
-                        responsiveCSS[breakpointKey] += ops[gridSettingKey](
-                            responsiveValue,
-                            middle
-                        );
+                        responsiveCSS[breakpointKey] += ops[gridSettingKey](responsiveValue);
                     }
                 }
             }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -71,6 +71,20 @@ declare module '@xstyled/system' {
         borderBottomColor?: ResponsiveValue<CSS.BorderBottomColorProperty>;
     }
 
+    export interface FlexboxProps<TLength = TLengthStyledSystem> {
+        display?: ResponsiveValue<CSS.DisplayProperty>;
+        alignItems?: ResponsiveValue<CSS.AlignItemsProperty>;
+        alignContent?: ResponsiveValue<CSS.AlignContentProperty>;
+        justifyContent?: ResponsiveValue<CSS.JustifyContentProperty>;
+        justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty>;
+        flexWrap?: ResponsiveValue<CSS.FlexWrapProperty>;
+        flexBasis?: ResponsiveValue<CSS.FlexBasisProperty<TLength>>;
+        flexDirection?: ResponsiveValue<CSS.FlexDirectionProperty>;
+        flex?: ResponsiveValue<CSS.FlexProperty<TLength>>;
+        justifySelf?: ResponsiveValue<CSS.JustifySelfProperty>;
+        alignSelf?: ResponsiveValue<CSS.AlignSelfProperty>;
+    }
+
     export interface LayoutProps<TLength = TLengthStyledSystem> {
         display?: ResponsiveValue<CSS.DisplayProperty>;
         width?: ResponsiveValue<CSS.WidthProperty<TLength>>;
@@ -223,6 +237,8 @@ declare module '@xstyled/system' {
     export const color: StyleFn;
 
     export const backgroundColor: StyleFn;
+
+    export const flexboxes: StyleFn;
 
     export const space: StyleFn;
     export const margin: StyleFn;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

* Adds `spacing` props from xstyled to `Cell` and `Grid`
* Adds more alignment options to `Cell` via the new `align` and `valign` props. `middle` and `center` still function until they can be deprecated
* `Cell` is now also exported as a child of `Grid` as well as a standalone component. This is a step on the standalone being deprecated.
* Adds `FlexboxProps` and `flexboxes` to xstyled's typings.
