### PR TITLE
feat(Collapse): add option to keep inactive panels in dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Collapse/Collapse.component.tsx
+++ b/src/Collapse/Collapse.component.tsx
@@ -30,6 +30,7 @@ interface CollapseProps extends React.HTMLAttributes<HTMLDivElement> {
     /** This mostly exists for CollapseGroup in order to hide the bottom border of stacked Collapse children */
     hasBottomBorder?: boolean;
     children?: any;
+    removeInactive?: boolean;
     className?: string;
 }
 
@@ -149,6 +150,10 @@ const StyledCollapse = styled('div')<StyledCollapseProps>`
             border-bottom-style: none;
         }
     }
+
+    .anchor-collapse-content.inactive {
+        display: none;
+    }
 `;
 StyledCollapse.displayName = 'StyledCollapse';
 
@@ -161,6 +166,7 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
     variant = DEFAULT_VARIANT,
     onClick,
     hasBottomBorder = true,
+    removeInactive = true,
     className,
     children,
     ...props
@@ -209,8 +215,13 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
                 )}
             </button>
 
-            {open && (
-                <section className="anchor-collapse-content">
+            {(open || !removeInactive) && (
+                <section
+                    className={classNames(
+                        'anchor-collapse-content',
+                        !open && 'inactive'
+                    )}
+                >
                     {children}
                 </section>
             )}

--- a/src/Collapse/Collapse.component.tsx
+++ b/src/Collapse/Collapse.component.tsx
@@ -29,8 +29,9 @@ interface CollapseProps extends React.HTMLAttributes<HTMLDivElement> {
     onClick?: any;
     /** This mostly exists for CollapseGroup in order to hide the bottom border of stacked Collapse children */
     hasBottomBorder?: boolean;
-    children?: any;
+    /** This specifies whether the contents of a closed collapse are removed from the dom vs hidden */
     removeInactive?: boolean;
+    children?: any;
     className?: string;
 }
 

--- a/src/Collapse/Collapse.spec.tsx
+++ b/src/Collapse/Collapse.spec.tsx
@@ -85,4 +85,20 @@ describe('Component: Collapse', () => {
 
         expect(wrapper.find('.anchor-icon.arrow-back').exists()).toBeTruthy();
     });
+
+    it('should keep closed content in the dom when removeInactive is false.', () => {
+        const subject = (
+            <Collapse isOpen={false} removeInactive={false}>
+                Hello World!
+            </Collapse>
+        );
+        const component = shallow(subject);
+
+        expect(
+            component.find('.anchor-collapse-content').exists()
+        ).toBeTruthy();
+
+        const tree = renderer.create(subject).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/src/Collapse/Collapse.stories.tsx
+++ b/src/Collapse/Collapse.stories.tsx
@@ -78,6 +78,7 @@ storiesOf('Components/Collapse', module)
                             'comfortable'
                         )}
                         isOpen={boolean('isOpen', false)}
+                        removeInactive={boolean('removeInactive', true)}
                         openedText={text('openedText', DEFAULT_OPENED_TEXT)}
                         closedText={text('closedText', DEFAULT_CLOSED_TEXT)}
                         hasBottomBorder={boolean('hasBottomBorder', true)}
@@ -124,6 +125,7 @@ storiesOf('Components/Collapse', module)
                             'comfortable'
                         )}
                         accordion={boolean('accordion', false)}
+                        removeInactive={boolean('removeInactive', true)}
                         openIndex={0}
                         openedIcon={React.createElement(Icon[iconOpenedPick], {
                             color: 'accent.base',

--- a/src/Collapse/CollapseGroup/CollapseGroup.component.tsx
+++ b/src/Collapse/CollapseGroup/CollapseGroup.component.tsx
@@ -25,6 +25,8 @@ interface CollapseGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     openedIcon?: React.ReactElement;
     /** By passing a closedIcon to the group, all Collapse children use that closedIcon */
     closedIcon?: React.ReactElement;
+    /** By passing removeInactive to the group, all Collapse children will receive that prop */
+    removeInactive?: boolean;
     /**
      * Realistically anything can be a child of CollapseGroup, but it's rather
      * pointless as it's intended to have Collapse components as children

--- a/src/Collapse/CollapseGroup/__snapshots__/CollapseGroup.spec.tsx.snap
+++ b/src/Collapse/CollapseGroup/__snapshots__/CollapseGroup.spec.tsx.snap
@@ -55,6 +55,10 @@ exports[`Component: CollapseGroup should match its snapshot. 1`] = `
   border-bottom-style: none;
 }
 
+.c0 .anchor-collapse-content.inactive {
+  display: none;
+}
+
 <div
   className="anchor-collapse-group"
 >

--- a/src/Collapse/__snapshots__/Collapse.spec.tsx.snap
+++ b/src/Collapse/__snapshots__/Collapse.spec.tsx.snap
@@ -1,5 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: Collapse should keep closed content in the dom when removeInactive is false. 1`] = `
+.c1 {
+  display: inline-block;
+  height: 1rem;
+  width: 1rem;
+  line-height: 0;
+  color: currentColor;
+}
+
+.c0 {
+  display: block;
+  box-sizing: border-box;
+  font-family: base;
+  padding: 1rem 2rem;
+  border-top: solid thin borders.base;
+  border-bottom: solid thin borders.base;
+}
+
+.c0 .anchor-collapse-button {
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  text-align: left;
+  border-style: none;
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.5rem 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c0 .anchor-collapse-button:focus {
+  outline: none;
+}
+
+.c0 .anchor-collapse-button span:last-child {
+  float: right;
+}
+
+.c0 .anchor-collapse-content {
+  font-size: 1rem;
+  text-align: left;
+  padding: 0.5rem 0;
+}
+
+.c0.no-bottom-border {
+  border-bottom-style: none;
+}
+
+.c0.no-bottom-border .anchor-collapse-button {
+  border-bottom-style: none;
+}
+
+.c0 .anchor-collapse-content.inactive {
+  display: none;
+}
+
+<div
+  className="c0 anchor-collapse comfortable"
+>
+  <button
+    className="anchor-collapse-button"
+    onClick={[Function]}
+  >
+    Open
+     
+    <span
+      className="c1 anchor-icon chevron-down"
+      scale="md"
+    >
+      <svg
+        height={16}
+        viewBox="0 0 16 16"
+        width={16}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 8.478l2.954-2.517a.77.77 0 0 1 1.058 0l.014.015a.721.721 0 0 1-.009 1.052L8.53 10.04a.767.767 0 0 1-1.048.008L3.975 7.02a.719.719 0 0 1-.001-1.042l.015-.015a.767.767 0 0 1 1.048-.01L8 8.477z"
+          fill="currentColor"
+          fillRule="nonzero"
+        />
+      </svg>
+    </span>
+  </button>
+  <section
+    className="anchor-collapse-content inactive"
+  >
+    Hello World!
+  </section>
+</div>
+`;
+
 exports[`Component: Collapse should match its snapshot. 1`] = `
 .c1 {
   display: inline-block;
@@ -53,6 +147,10 @@ exports[`Component: Collapse should match its snapshot. 1`] = `
 
 .c0.no-bottom-border .anchor-collapse-button {
   border-bottom-style: none;
+}
+
+.c0 .anchor-collapse-content.inactive {
+  display: none;
 }
 
 <div

--- a/src/PopOver/PopOver.component.tsx
+++ b/src/PopOver/PopOver.component.tsx
@@ -78,9 +78,7 @@ export class PopOver extends React.PureComponent<
             position !== prevPosition ||
             spacing !== prevSpacing
         ) {
-            const {
-                current: popOver,
-            }: { current: any } = this.popOverRef;
+            const { current: popOver }: { current: any } = this.popOverRef;
             const {
                 current: popOverContainer,
             }: { current: any } = this.popOverContainerRef;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Adds a `removeInactive` prop to `Collapse` components, to give the option to hide with `display: none` instead of removing from dom.
