### PR TITLE
feat: update DropDown and Popover dimensions when activated

### DIFF
--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -153,7 +153,11 @@ export class DropDown extends React.Component<DropDownProps> {
             escapeKey$.pipe(mapTo(false)),
             dropDownClick$.pipe(map(() => !this.state.clicked))
         ).subscribe(clicked => {
-            this.setState({ clicked });
+            this.setState(({ height, width }: DropDownState) => ({
+                clicked,
+                height: clicked ? get(dropDown, 'clientHeight', 0) : height,
+                width: clicked ? get(dropDown, 'clientWidth', 0) : width,
+            }));
             if (this.props.onTriggered) {
                 this.props.onTriggered(clicked);
             }
@@ -174,7 +178,12 @@ export class DropDown extends React.Component<DropDownProps> {
                 distinctUntilChanged()
             )
             .subscribe(hovered => {
-                this.setState({ hovered });
+                this.setState(({ height, width }: DropDownState) => ({
+                    hovered,
+                    height: hovered ? get(dropDown, 'clientHeight', 0) : height,
+                    width: hovered ? get(dropDown, 'clientWidth', 0) : width,
+                }));
+
                 if (this.props.onTriggered) {
                     this.props.onTriggered(hovered);
                 }

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -160,4 +160,48 @@ storiesOf('Components/DropDown', module)
                 </Grid>
             </StyledStory>
         </ThemeProvider>
+    ))
+    .add('Resize Demo', () => (
+        <ThemeProvider theme={RootTheme}>
+            <StyledStory>
+                <Typography tag="h1">DropDown</Typography>
+                <DropDown
+                    overlay={<MockList />}
+                    position={select<Position>(
+                        'position',
+                        [
+                            'topStart',
+                            'top',
+                            'topEnd',
+                            'rightStart',
+                            'right',
+                            'rightEnd',
+                            'bottomEnd',
+                            'bottom',
+                            'bottomStart',
+                            'leftEnd',
+                            'left',
+                            'leftStart',
+                        ],
+                        'bottom'
+                    )}
+                    trigger={select<Trigger>(
+                        'trigger',
+                        ['click', 'hover', 'both'],
+                        'hover'
+                    )}
+                    showArrow={boolean('showArrow', true)}
+                    shadow={text('shadow', '') || undefined}
+                    background={text('background', '') || undefined}
+                    border={text('border', '') || undefined}
+                    borderRadius={text('borderRadius', '') || undefined}
+                    arrowIndent={text('arrowIndent', '') || undefined}
+                    arrowSize={text('arrowSize', '') || undefined}
+                    spacing={text('spacing', '') || undefined}
+                    debug={boolean('Debug', false)}
+                >
+                    <textarea defaultValue={text('Text', 'Resize me')} />
+                </DropDown>
+            </StyledStory>
+        </ThemeProvider>
     ));

--- a/src/PopOver/PopOver.component.tsx
+++ b/src/PopOver/PopOver.component.tsx
@@ -1,6 +1,7 @@
 // VENDOR
 import * as React from 'react';
 import styled from '@xstyled/styled-components';
+import { DisplayProps, display as displayStyles } from '@xstyled/system';
 import classNames from 'classnames';
 // COMPONENTS
 import { Position } from '../utils/position/position';
@@ -8,7 +9,9 @@ import { PositionContainer } from '../utils/PositionContainer';
 // UTILS
 import { get } from '../utils/get/get';
 
-interface PopOverContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+interface PopOverContainerProps
+    extends React.HTMLAttributes<HTMLDivElement>,
+        DisplayProps {
     arrowIndent?: string;
     arrowSize?: string;
     background?: string;
@@ -33,8 +36,15 @@ interface PopOverContainerState {
     containerWidth: number;
 }
 
-const StyledPopOver = styled('div')`
+interface StyledPopOverProps extends DisplayProps {}
+
+const StyledPopOver = styled('div')<StyledPopOverProps>`
+    ${displayStyles}
     position: relative;
+    display: inline-flex;
+    box-sizing: border-box;
+    justify-content: center;
+    align-items: center;
 `;
 
 export class PopOver extends React.PureComponent<
@@ -70,10 +80,12 @@ export class PopOver extends React.PureComponent<
             showArrow: prevShowArrow,
             position: prevPosition,
             spacing: prevSpacing,
+            active: prevActive,
         } = prevProps;
-        const { showArrow, position, spacing } = this.props;
+        const { showArrow, position, spacing, active } = this.props;
 
         if (
+            (active && !prevActive) ||
             showArrow !== prevShowArrow ||
             position !== prevPosition ||
             spacing !== prevSpacing
@@ -110,6 +122,7 @@ export class PopOver extends React.PureComponent<
             maxWidth,
             position = 'bottomStart',
             showArrow,
+            display = 'inline-block',
             active,
             ...props
         } = this.props;
@@ -117,6 +130,7 @@ export class PopOver extends React.PureComponent<
         return (
             <StyledPopOver
                 className={classNames('anchor-pop-over', className)}
+                display={display}
                 {...props}
                 ref={this.popOverRef}
             >

--- a/src/PopOver/PopOver.stories.tsx
+++ b/src/PopOver/PopOver.stories.tsx
@@ -116,7 +116,10 @@ storiesOf('Components/PopOver', module)
                     border={text('Border', '') || undefined}
                     borderRadius={text('Border Radius', '') || undefined}
                     color={text('Color', '') || undefined}
-                    content={text('Content', 'Text')}
+                    content={text(
+                        'Content',
+                        'Will reposition when newly active.'
+                    )}
                     position={select<Position>(
                         'Position',
                         [

--- a/src/PopOver/PopOver.stories.tsx
+++ b/src/PopOver/PopOver.stories.tsx
@@ -105,6 +105,50 @@ storiesOf('Components/PopOver', module)
             </StyledStory>
         </ThemeProvider>
     ))
+    .add('Resizeable', () => (
+        <ThemeProvider theme={RootTheme}>
+            <StyledStory>
+                <Typography tag="h1">PopOver</Typography>
+                <PopOver
+                    active={boolean('Active', true)}
+                    delay={text('Animation Delay', '') || undefined}
+                    background={text('Background', '') || undefined}
+                    border={text('Border', '') || undefined}
+                    borderRadius={text('Border Radius', '') || undefined}
+                    color={text('Color', '') || undefined}
+                    content={text('Content', 'Text')}
+                    position={select<Position>(
+                        'Position',
+                        [
+                            'topStart',
+                            'top',
+                            'topEnd',
+                            'rightStart',
+                            'right',
+                            'rightEnd',
+                            'bottomEnd',
+                            'bottom',
+                            'bottomStart',
+                            'leftEnd',
+                            'left',
+                            'leftStart',
+                        ],
+                        'bottom'
+                    )}
+                    shadow={
+                        text('Shadow (buggy in Storybook)', '') || undefined
+                    }
+                    spacing={number('Spacing', 8) || undefined}
+                    showArrow={boolean('Show Arrow', true)}
+                    arrowIndent={text('Arrow Indent', '') || undefined}
+                    arrowSize={text('Arrow Size', '') || undefined}
+                    debug={boolean('Debug', false)}
+                >
+                    <textarea />
+                </PopOver>
+            </StyledStory>
+        </ThemeProvider>
+    ))
     .add('Button to Control', () => (
         <ThemeProvider theme={RootTheme}>
             <StyledStory>

--- a/src/PopOver/__snapshots__/PopOver.spec.tsx.snap
+++ b/src/PopOver/__snapshots__/PopOver.spec.tsx.snap
@@ -107,11 +107,26 @@ exports[`Component: PopOver should be defined. 1`] = `
 }
 
 .c0 {
+  display: inline-block;
   position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  box-sizing: border-box;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <div
   className="c0 anchor-pop-over"
+  display="inline-block"
 >
   <button
     className="c1 anchor-button"


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Updates dropdown/popover dimensions when newly activated