### PR TITLE
chore: add a trigger type argument to DropDown onTrigger

### DIFF
--- a/src/DropDown/DropDown.component.spec.tsx
+++ b/src/DropDown/DropDown.component.spec.tsx
@@ -35,4 +35,44 @@ describe('Component: DropDown', () => {
             wrapper.find('div.anchor-drop-down-container.active').exists()
         ).toBeFalsy();
     });
+    test('should fire onTriggered with correct type when clicked', () => {
+        const onTrigMock = jest.fn();
+        const subject = (
+            <DropDown
+                overlay={<div>1</div>}
+                trigger="click"
+                onTriggered={onTrigMock}
+            />
+        );
+        const wrapper = mount(subject);
+        wrapper.getDOMNode().dispatchEvent(new MouseEvent('click'));
+        expect(onTrigMock).toHaveBeenCalledWith(true, 'click');
+    });
+    test('should fire onTriggered with correct type when hovered', () => {
+        const onTrigMock = jest.fn();
+        const subject = (
+            <DropDown
+                overlay={<div>1</div>}
+                trigger="hover"
+                onTriggered={onTrigMock}
+            />
+        );
+        const wrapper = mount(subject);
+        wrapper.getDOMNode().dispatchEvent(new MouseEvent('mouseenter'));
+        expect(onTrigMock).toHaveBeenCalledWith(true, 'hover');
+    });
+    test('should fire onTriggered with false when clicked twice', () => {
+        const onTrigMock = jest.fn();
+        const subject = (
+            <DropDown
+                overlay={<div>1</div>}
+                trigger="click"
+                onTriggered={onTrigMock}
+            />
+        );
+        const wrapper = mount(subject);
+        wrapper.setState({ clicked: true });
+        wrapper.getDOMNode().dispatchEvent(new MouseEvent('click'));
+        expect(onTrigMock).toHaveBeenCalledWith(false, 'click');
+    });
 });

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -24,7 +24,7 @@ interface DropDownProps extends React.HTMLAttributes<HTMLDivElement> {
     border?: string;
     borderRadius?: string;
     debug?: boolean;
-    onTriggered?: (state: boolean) => void;
+    onTriggered?: (state: boolean, trigger?: string) => void;
     position?: Position;
     ref?: any;
     shadow?: string;
@@ -159,7 +159,7 @@ export class DropDown extends React.Component<DropDownProps> {
                 width: clicked ? get(dropDown, 'clientWidth', 0) : width,
             }));
             if (this.props.onTriggered) {
-                this.props.onTriggered(clicked);
+                this.props.onTriggered(clicked, 'click');
             }
         });
 
@@ -185,7 +185,7 @@ export class DropDown extends React.Component<DropDownProps> {
                 }));
 
                 if (this.props.onTriggered) {
-                    this.props.onTriggered(hovered);
+                    this.props.onTriggered(hovered, 'hover');
                 }
             });
     }


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**
- Added string parameter to the onTrigger function to specify the type of trigger (so parent components can build custom logic around dropdown)
- Unit tests