### PR TITLE
fix: theme merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/utils/themeMerge/themeMerge.spec.tsx
+++ b/src/utils/themeMerge/themeMerge.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable dot-notation */
 // VENDOR
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
@@ -18,6 +19,7 @@ const TestTheme = {
     colors: {
         primary: {
             base: '#ff0000',
+            lighter: '#ee0000',
         },
     },
     radii: {
@@ -60,9 +62,13 @@ describe('theme: themeMerge()', () => {
         expect(subject.radii['circular']).toBeUndefined();
     });
 
-    it('should have newly added root keys and values', () => {
+    it('should have newly updated root keys and values', () => {
         expect(subject.exampleComponent.xs).toBe('1rem');
         expect(subject.exampleComponent.md).toBe('2rem');
+    });
+
+    it('should have completely new key/values', () => {
+        expect(subject.colors['primary'].lighter).toBe('#ee0000');
     });
 
     it('should not mutate RootTheme', () => {

--- a/src/utils/themeMerge/themeMerge.ts
+++ b/src/utils/themeMerge/themeMerge.ts
@@ -25,7 +25,7 @@ export type ThemeType = {
 };
 
 // Can't really be 100% sure what data will be as it is cloned, hence :any
-function deepClone(data: any) {
+function deepClone(data: any): any {
     if (typeof data === null || typeof data !== 'object') {
         return data;
     }
@@ -41,12 +41,20 @@ function deepClone(data: any) {
     return tmpObj;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function recursiveUpdate(settingStep: object, newThemeStep: object) {
     for (const key in settingStep) {
+        // If the user has passed undefined as a value, delete the associated property
+        // Else if the value isn't an object then update the theme with that value
+        // Else if the key doesn't already exist in the new theme, add it, and continue recursion
+        // Else continue recursion
         if (settingStep[key] === undefined) {
             delete newThemeStep[key];
         } else if (settingStep[key] && typeof settingStep[key] !== 'object') {
             newThemeStep[key] = settingStep[key];
+        } else if (settingStep[key] && !newThemeStep[key]) {
+            newThemeStep[key] = {};
+            recursiveUpdate(settingStep[key], newThemeStep[key]);
         } else {
             recursiveUpdate(settingStep[key], newThemeStep[key]);
         }


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

**Kind of a fix, kind of a feature.** 

`themeMerge()` can now add new keys to existing root properties. i.e:

```
const newTheme = themeMerge({
  colors: {
    primary: {
      lightest: '#d8ccdf',
      darkest: '#4b2354',
    },
});
```


