### PR TITLE
fix: themeMerge properly merges keys with 0 or false as values

### DIFF
--- a/src/utils/themeMerge/themeMerge.spec.tsx
+++ b/src/utils/themeMerge/themeMerge.spec.tsx
@@ -33,6 +33,7 @@ const TestTheme = {
     exampleComponent: {
         xs: '1rem',
         md: '2rem',
+        render: false,
     },
 };
 
@@ -117,5 +118,11 @@ describe('theme: themeMerge()', () => {
 
         const tree = renderer.create(<Test />).toJSON();
         expect(tree).toMatchSnapshot();
+    });
+
+    it('should copy keys even if their values are false or 0', () => {
+        expect(RootTheme.breakpoints.xs).toBe(0);
+        expect(subject.breakpoints.xs).toBe(0);
+        expect(subject.exampleComponent.render).toBe(false);
     });
 });

--- a/src/utils/themeMerge/themeMerge.ts
+++ b/src/utils/themeMerge/themeMerge.ts
@@ -34,7 +34,7 @@ function deepClone(data: any): any {
     const tmpObj = data.constructor();
 
     for (const key in data) {
-        if (data[key]) {
+        if (data.hasOwnProperty(key)) {
             tmpObj[key] = deepClone(data[key]);
         }
     }
@@ -43,16 +43,20 @@ function deepClone(data: any): any {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function recursiveUpdate(settingStep: object, newThemeStep: object) {
+    // eslint-disable-next-line guard-for-in
     for (const key in settingStep) {
         // If the user has passed undefined as a value, delete the associated property
         // Else if the value isn't an object then update the theme with that value
         // Else if the key doesn't already exist in the new theme, add it, and continue recursion
         // Else continue recursion
-        if (settingStep[key] === undefined) {
+        if (settingStep.hasOwnProperty(key) && settingStep[key] === undefined) {
             delete newThemeStep[key];
-        } else if (settingStep[key] && typeof settingStep[key] !== 'object') {
+        } else if (
+            settingStep.hasOwnProperty(key) &&
+            typeof settingStep[key] !== 'object'
+        ) {
             newThemeStep[key] = settingStep[key];
-        } else if (settingStep[key] && !newThemeStep[key]) {
+        } else if (settingStep.hasOwnProperty(key) && !newThemeStep[key]) {
             newThemeStep[key] = {};
             recursiveUpdate(settingStep[key], newThemeStep[key]);
         } else {
@@ -66,7 +70,6 @@ export function themeMerge(
     baseTheme: ThemeType = RootTheme
 ): ThemeType {
     const newTheme = deepClone(baseTheme);
-
     for (const key in settings) {
         if (settings[key]) {
             if (!newTheme.hasOwnProperty(key)) {


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
