### PR TITLE
fix(Typography): allow css blocks for its variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Adapt/Adapt.component.spec.tsx
+++ b/src/Adapt/Adapt.component.spec.tsx
@@ -12,7 +12,7 @@ describe('Component: Adapt', () => {
             <ThemeProvider theme={RootTheme}>
                 <Adapt forEach={{ xs: 'blue', md: 'green' }}>
                     {(value, breakpoint) => (
-                        <div>{`${value} | ${breakpoint}`}</div>
+                        <div key={breakpoint}>{`${value} | ${breakpoint}`}</div>
                     )}
                 </Adapt>
             </ThemeProvider>
@@ -26,7 +26,7 @@ describe('Component: Adapt', () => {
             <ThemeProvider theme={RootTheme}>
                 <Adapt forEach={{ md: 'green' }}>
                     {(value, breakpoint) => (
-                        <div>{`${value} | ${breakpoint}`}</div>
+                        <div key={breakpoint}>{`${value} | ${breakpoint}`}</div>
                     )}
                 </Adapt>
             </ThemeProvider>
@@ -40,7 +40,7 @@ describe('Component: Adapt', () => {
             <ThemeProvider theme={RootTheme}>
                 <Adapt forEach={{ md: 'green', xs: 'blue' }}>
                     {(value, breakpoint) => (
-                        <div>{`${value} | ${breakpoint}`}</div>
+                        <div key={breakpoint}>{`${value} | ${breakpoint}`}</div>
                     )}
                 </Adapt>
             </ThemeProvider>

--- a/src/Typography/Typography.component.spec.tsx
+++ b/src/Typography/Typography.component.spec.tsx
@@ -15,6 +15,11 @@ const themeWithCssBlockVariant = themeMerge({
                 background-color: blue;
             `,
         },
+        scale: {
+            24: css`
+                background-color: green;
+            `,
+        },
     },
 });
 
@@ -156,6 +161,19 @@ describe('Component: Typography', () => {
         const subject = (
             <ThemeProvider theme={themeWithCssBlockVariant}>
                 <Typography className="customClass" as="h5">
+                    Typography customClass
+                </Typography>
+            </ThemeProvider>
+        );
+
+        const tree = renderer.create(subject).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('should work with css block scale variants', () => {
+        const subject = (
+            <ThemeProvider theme={themeWithCssBlockVariant}>
+                <Typography className="customClass" scale={24}>
                     Typography customClass
                 </Typography>
             </ThemeProvider>

--- a/src/Typography/Typography.component.spec.tsx
+++ b/src/Typography/Typography.component.spec.tsx
@@ -3,9 +3,20 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { Typography } from './Typography.component';
-import styled, { ThemeProvider } from '@xstyled/styled-components';
+import styled, { css, ThemeProvider } from '@xstyled/styled-components';
 // ANCHOR
 import { RootTheme } from '../theme';
+import { themeMerge } from '../utils/themeMerge';
+
+const themeWithCssBlockVariant = themeMerge({
+    typography: {
+        as: {
+            h5: css`
+                background-color: blue;
+            `,
+        },
+    },
+});
 
 describe('Component: Typography', () => {
     it('match its snapshot', () => {
@@ -121,6 +132,45 @@ describe('Component: Typography', () => {
                 <RedText as="h1" className="customClass">
                     RedText h1 customClass
                 </RedText>
+            </ThemeProvider>
+        );
+
+        const tree = renderer.create(subject).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('scale should take precendence over as variants', () => {
+        const subject = (
+            <ThemeProvider theme={RootTheme}>
+                <Typography className="customClass" as="h5" scale={32}>
+                    Typography customClass
+                </Typography>
+            </ThemeProvider>
+        );
+
+        const tree = renderer.create(subject).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('should work with css block as-variants', () => {
+        const subject = (
+            <ThemeProvider theme={themeWithCssBlockVariant}>
+                <Typography className="customClass" as="h5">
+                    Typography customClass
+                </Typography>
+            </ThemeProvider>
+        );
+
+        const tree = renderer.create(subject).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it('scale should still take precendence with css block as-variants', () => {
+        const subject = (
+            <ThemeProvider theme={themeWithCssBlockVariant}>
+                <Typography className="customClass" as="h5" scale={32}>
+                    Typography customClass
+                </Typography>
             </ThemeProvider>
         );
 

--- a/src/Typography/Typography.component.tsx
+++ b/src/Typography/Typography.component.tsx
@@ -118,6 +118,7 @@ export const Typography = styled('span').attrs<TypographyProps>(props => ({
             fontWeight: th('typography.fontWeight'),
             textAlign: 'inherit',
             color: 'inherit',
+            // Don't include variants that are css-blocks
             ...(!isArray(asVariant) ? asVariant : {}),
             ...(!isArray(asVariant) && !isArray(scaleVariant)
                 ? scaleVariant

--- a/src/Typography/Typography.component.tsx
+++ b/src/Typography/Typography.component.tsx
@@ -8,6 +8,8 @@ import { space as spaceStyles, SpaceProps } from '@xstyled/system';
 import { Scale } from '../theme/typography.theme';
 import { rem } from '../utils/rem/rem';
 
+const { isArray } = Array;
+
 export type FontWeights =
     | 'normal'
     | 'bold'
@@ -84,21 +86,31 @@ export interface TypographyProps extends SpaceProps, React.HTMLAttributes<any> {
 
 export interface StyledTypographyProps extends TypographyProps {
     $color?: 'inherit' | 'initial' | string;
+    asVariant?: any;
+    scaleVariant?: any;
 }
 
-export const Typography = styled('span').attrs<TypographyProps>(
-    ({ color }) => ({
-        $color: color,
-        color: undefined,
-        className: 'anchor-typography',
-    })
-)<StyledTypographyProps>`
+export const Typography = styled('span').attrs<TypographyProps>(props => ({
+    $color: props.color,
+    color: undefined,
+    className: 'anchor-typography',
+    asVariant: variant({
+        key: 'typography.as',
+        default: 'none',
+        prop: 'as',
+    })(props),
+    scaleVariant: variant({
+        key: 'typography.scale',
+        default: 'none',
+        prop: 'scale',
+    })(props),
+}))<StyledTypographyProps>`
 
     box-sizing: border-box;
     margin: 0;
 
     // Variant styles
-    ${props =>
+    ${({ asVariant, scaleVariant }) =>
         css({
             fontFamily: 'base',
             fontSize: th('typography.fontSize'),
@@ -106,17 +118,18 @@ export const Typography = styled('span').attrs<TypographyProps>(
             fontWeight: th('typography.fontWeight'),
             textAlign: 'inherit',
             color: 'inherit',
-            ...variant({
-                key: 'typography.as',
-                default: 'none',
-                prop: 'as',
-            })(props),
-            ...variant({
-                key: 'typography.scale',
-                default: 'none',
-                prop: 'scale',
-            })(props),
+            ...(!isArray(asVariant) ? asVariant : {}),
+            ...(!isArray(asVariant) && !isArray(scaleVariant)
+                ? scaleVariant
+                : {}),
         })}
+
+    // If the "asVariant" is a css block, then we aren't spreading it above and must
+    // include it here. We also include the scale variant so that it's still defined
+    // "after" the as variant, and takes precedence.
+    ${({ asVariant }) => isArray(asVariant) && asVariant}
+    ${({ scaleVariant, asVariant }) =>
+        (isArray(asVariant) || isArray(scaleVariant)) && scaleVariant}
 
     // Prop overrides. We don't have any defaults here because then they
     // would always override the variants above.

--- a/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
+++ b/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
@@ -23,6 +23,57 @@ exports[`Component: Typography match its snapshot 1`] = `
 </span>
 `;
 
+exports[`Component: Typography scale should still take precendence with css block as-variants 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin: 0;
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  font-size: 16px;
+  line-height: 1.5rem;
+  font-weight: normal;
+  text-align: inherit;
+  color: inherit;
+  background-color: blue;
+  font-size: 2rem;
+  line-height: 2.5rem;
+}
+
+.c0 small {
+  font-size: 87.5%;
+}
+
+<h5
+  className="c0 customClass anchor-typography"
+  scale={32}
+>
+  Typography customClass
+</h5>
+`;
+
+exports[`Component: Typography scale should take precendence over as variants 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin: 0;
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  font-size: 2rem;
+  line-height: 2.5rem;
+  font-weight: normal;
+  text-align: inherit;
+  color: inherit;
+}
+
+.c0 small {
+  font-size: 87.5%;
+}
+
+<h5
+  className="c0 customClass anchor-typography"
+  scale={32}
+>
+  Typography customClass
+</h5>
+`;
+
 exports[`Component: Typography should accept a custom display 1`] = `
 .c0 {
   box-sizing: border-box;
@@ -210,4 +261,28 @@ exports[`Component: Typography should be extendable via styled 2`] = `
 >
   I should be an h1 and be red!
 </h1>
+`;
+
+exports[`Component: Typography should work with css block as-variants 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin: 0;
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  font-size: 16px;
+  line-height: 1.5rem;
+  font-weight: normal;
+  text-align: inherit;
+  color: inherit;
+  background-color: blue;
+}
+
+.c0 small {
+  font-size: 87.5%;
+}
+
+<h5
+  className="c0 customClass anchor-typography"
+>
+  Typography customClass
+</h5>
 `;

--- a/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
+++ b/src/Typography/__snapshots__/Typography.component.spec.tsx.snap
@@ -286,3 +286,28 @@ exports[`Component: Typography should work with css block as-variants 1`] = `
   Typography customClass
 </h5>
 `;
+
+exports[`Component: Typography should work with css block scale variants 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin: 0;
+  font-family: Avenir Next,Segoe UI,Helvetica Neue,Helvetica,Roboto,sans-serif;
+  font-size: 16px;
+  line-height: 1.5rem;
+  font-weight: normal;
+  text-align: inherit;
+  color: inherit;
+  background-color: green;
+}
+
+.c0 small {
+  font-size: 87.5%;
+}
+
+<span
+  className="c0 customClass anchor-typography"
+  scale={24}
+>
+  Typography customClass
+</span>
+`;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Allows typography theme variants to be css blocks
