### PR TITLE
fix(Collapse): stop collapse icon from wrapping under button text

### DIFF
--- a/docs/src/pages/components/collapse.mdx
+++ b/docs/src/pages/components/collapse.mdx
@@ -66,7 +66,8 @@ The **`CollapseGroup`** component combines multiple **`Collapse`** components to
     },
     {
         property: 'closedText',
-        description: 'The text that appears on the button as a CTA when the component is closed.',
+        description: 'The text that appears on the button as a CTA when the component is closed.
+            Defaults to <pre>openedText</pre> if that has been set.',
         type: 'string',
         default: 'Open',
     },

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ ReactDOM.render(Root, document.getElementById('app'));
 ### Why Anchor?
 
 * **Isomorphic** - We are an isomorphic-first library which doesn't require a Webpack expert
-* **Convention** Over Configuration - Out of the box this library solves common challenges faced by UI engineers without a ton of configuration
+* **Convention Over Configuration** - Out of the box this library solves common challenges faced by UI engineers without a ton of configuration
 * **Composability** - Rather than writing redundant overrides, we provide consistent attributes to easily change the look and feel of our components
 * **Community** - We promote people-centric solutions and promote a culture of learners
 * **Representational** - We try to use native DOM APIs so the better you know the DOM the easier this library is to use

--- a/src/Collapse/Collapse.component.tsx
+++ b/src/Collapse/Collapse.component.tsx
@@ -58,8 +58,11 @@ const variants = {
         border-bottom: solid thin ${th.color('borders.base')};
 
         .anchor-collapse-button {
+            appearance: none;
+            background-color: transparent; /* Everyone but Chrome shows a grey bg without this, despite 'appearance: none' */
             cursor: pointer;
-            display: block;
+            display: flex;
+            justify-content: space-between;
             width: 100%;
             text-align: left;
             border-style: none;
@@ -72,8 +75,9 @@ const variants = {
                 outline: none;
             }
 
-            span:last-child {
-                float: right;
+            > *:last-child {
+                flex: 0 0 auto;
+                padding-left: 0.5em;
             }
         }
 
@@ -87,13 +91,15 @@ const variants = {
         color: text.light;
 
         .anchor-collapse-button {
-            background-color: white;
+            appearance: none;
+            background-color: transparent; /* Everyone but Chrome shows a grey bg without this, despite 'appearance: none' */
             border-style: none;
             border-bottom: light;
             border-top: light;
             color: text.light;
             cursor: pointer;
-            display: block;
+            display: flex;
+            justify-content: space-between;
             font-weight: bold;
             height: 3rem;
             padding: 0 1.3125rem;
@@ -105,8 +111,9 @@ const variants = {
                 outline: none;
             }
 
-            *:last-child {
-                float: right;
+            > *:last-child {
+                flex: 0 0 auto;
+                padding-left: 0.5em;
             }
         }
 
@@ -215,13 +222,13 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
                 className="anchor-collapse-button"
             >
                 {open ? (
-                    <React.Fragment>
+                    <>
                         {openedText} {IconOpened}
-                    </React.Fragment>
+                    </>
                 ) : (
-                    <React.Fragment>
+                    <>
                         {textClosed} {IconClosed}
-                    </React.Fragment>
+                    </>
                 )}
             </button>
 

--- a/src/Collapse/CollapseGroup/CollapseGroup.component.tsx
+++ b/src/Collapse/CollapseGroup/CollapseGroup.component.tsx
@@ -57,6 +57,9 @@ export const CollapseGroup: React.FunctionComponent<CollapseGroupProps> = ({
             {children &&
                 children.map((child: any, index: number) =>
                     React.cloneElement(child, {
+                        // TODO: Even if not explicitly set, this forces all child Collapse components
+                        // to closed because `undefined` is falsy.  Additionally, this is overwritten
+                        // if `isOpen` is explicitly set, because `...props` is spread below.
                         isOpen: accordion
                             ? index === currentOpenIndex
                             : undefined,

--- a/src/Collapse/CollapseGroup/__snapshots__/CollapseGroup.component.spec.tsx.snap
+++ b/src/Collapse/CollapseGroup/__snapshots__/CollapseGroup.component.spec.tsx.snap
@@ -19,8 +19,19 @@ exports[`Component: CollapseGroup should match its snapshot. 1`] = `
 }
 
 .c0 .anchor-collapse-button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   width: 100%;
   text-align: left;
   border-style: none;
@@ -37,8 +48,11 @@ exports[`Component: CollapseGroup should match its snapshot. 1`] = `
   outline: none;
 }
 
-.c0 .anchor-collapse-button span:last-child {
-  float: right;
+.c0 .anchor-collapse-button > *:last-child {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 0.5em;
 }
 
 .c0 .anchor-collapse-content {

--- a/src/Collapse/__snapshots__/Collapse.component.spec.tsx.snap
+++ b/src/Collapse/__snapshots__/Collapse.component.spec.tsx.snap
@@ -19,8 +19,19 @@ exports[`Component: Collapse should keep closed content in the dom when removeIn
 }
 
 .c0 .anchor-collapse-button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   width: 100%;
   text-align: left;
   border-style: none;
@@ -37,8 +48,11 @@ exports[`Component: Collapse should keep closed content in the dom when removeIn
   outline: none;
 }
 
-.c0 .anchor-collapse-button span:last-child {
-  float: right;
+.c0 .anchor-collapse-button > *:last-child {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 0.5em;
 }
 
 .c0 .anchor-collapse-content {
@@ -113,8 +127,19 @@ exports[`Component: Collapse should match its snapshot. 1`] = `
 }
 
 .c0 .anchor-collapse-button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   width: 100%;
   text-align: left;
   border-style: none;
@@ -131,8 +156,11 @@ exports[`Component: Collapse should match its snapshot. 1`] = `
   outline: none;
 }
 
-.c0 .anchor-collapse-button span:last-child {
-  float: right;
+.c0 .anchor-collapse-button > *:last-child {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 0.5em;
 }
 
 .c0 .anchor-collapse-content {


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Because the floated button icon came after the button text, if the icon needed to wrap, it would wrap under the text.  The solution is either to move the floated icon to be the first child of the button or to go with a flex-based approach.  Making the parent button a flexbox allows the icon to come second, which is more intuitive, and the default `align-items: stretch` rule means that all of the vertical space beneath the icon will be reserved, so button text will never wrap under the icon.  Additional tweaks were made to appearance and background-color, because in browsers other than Chrome a default "buttonFace" color (grey) was still showing through on this control.

Some docs were also updated for clarity or formatting purposes.

An issue with `isOpen` was identified in `CollapseGroup` with a TODO.