### PR TITLE
fix(Collapse): use margin not padding to reserve space next to icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Collapse/Collapse.component.tsx
+++ b/src/Collapse/Collapse.component.tsx
@@ -77,7 +77,7 @@ const variants = {
 
             > *:last-child {
                 flex: 0 0 auto;
-                padding-left: 0.5em;
+                margin-left: 0.5em;
             }
         }
 
@@ -113,7 +113,7 @@ const variants = {
 
             > *:last-child {
                 flex: 0 0 auto;
-                padding-left: 0.5em;
+                margin-left: 0.5em;
             }
         }
 

--- a/src/Collapse/CollapseGroup/__snapshots__/CollapseGroup.component.spec.tsx.snap
+++ b/src/Collapse/CollapseGroup/__snapshots__/CollapseGroup.component.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`Component: CollapseGroup should match its snapshot. 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  padding-left: 0.5em;
+  margin-left: 0.5em;
 }
 
 .c0 .anchor-collapse-content {

--- a/src/Collapse/__snapshots__/Collapse.component.spec.tsx.snap
+++ b/src/Collapse/__snapshots__/Collapse.component.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`Component: Collapse should keep closed content in the dom when removeIn
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  padding-left: 0.5em;
+  margin-left: 0.5em;
 }
 
 .c0 .anchor-collapse-content {
@@ -160,7 +160,7 @@ exports[`Component: Collapse should match its snapshot. 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  padding-left: 0.5em;
+  margin-left: 0.5em;
 }
 
 .c0 .anchor-collapse-content {


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

In my previous Collapse-related commit, I used `padding-left` to guarantee button text could not run directly into the side of the icon.  However, the icon will typically be an Anchor `Icon`, which already has an explicit `width` and `height` set.  Using padding (in combination with the globally defaulted `box-sizing: border-box`) means that `padding-left` actually steals space from the explicit `width` rather than adding to it.  The choice is either to set `box-sizing: content-box` (which seems unintuitive), or to simply use `margin-left` instead.
