### PR TITLE
fix(Skeleton): support multiple color schemes

### DIFF
--- a/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
+++ b/src/AutoComplete/ResultsContainer/__snapshots__/ResultsContainer.component.spec.tsx.snap
@@ -137,7 +137,7 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
       onMouseOver={[Function]}
     >
       <span
-        className="sc-pzMyG c2 lg anchor-typography"
+        className="sc-pHIBf c2 lg anchor-typography"
       >
         Result Item 1
       </span>
@@ -149,7 +149,7 @@ exports[`Component: ResultsContainer should accept a resultTemplate 1`] = `
       onMouseOver={[Function]}
     >
       <span
-        className="sc-pzMyG c2 lg anchor-typography"
+        className="sc-pHIBf c2 lg anchor-typography"
       >
         Result Item 2
       </span>
@@ -300,7 +300,7 @@ exports[`Component: ResultsContainer should be defined 1`] = `
       onMouseOver={[Function]}
     >
       <span
-        className="sc-pzMyG c3 lg anchor-typography"
+        className="sc-pHIBf c3 lg anchor-typography"
       >
         Result Item 1
       </span>
@@ -313,7 +313,7 @@ exports[`Component: ResultsContainer should be defined 1`] = `
       onMouseOver={[Function]}
     >
       <span
-        className="sc-pzMyG c3 lg anchor-typography"
+        className="sc-pHIBf c3 lg anchor-typography"
       >
         Result Item 2
       </span>

--- a/src/Form/ControlLabel/__snapshots__/ControlLabel.component.spec.tsx.snap
+++ b/src/Form/ControlLabel/__snapshots__/ControlLabel.component.spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`Component: ControlLabel should be defined 1`] = `
 }
 
 <label
-  className="sc-pzMyG c0 anchor-control-label anchor-typography"
+  className="sc-pHIBf c0 anchor-control-label anchor-typography"
   label="label"
   value="value"
 >

--- a/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
+++ b/src/List/Item/__snapshots__/Item.component.spec.tsx.snap
@@ -119,7 +119,7 @@ exports[`Component: Item should be defined 1`] = `
   onMouseOver={[Function]}
 >
   <span
-    className="sc-pzMyG c1 lg anchor-typography"
+    className="sc-pHIBf c1 lg anchor-typography"
   >
     Item
   </span>

--- a/src/Skeleton/Skeleton.component.spec.tsx
+++ b/src/Skeleton/Skeleton.component.spec.tsx
@@ -57,4 +57,27 @@ describe('Component: Skeleton', () => {
         const tree = renderer.create(subject).toJSON();
         expect(tree).toMatchSnapshot();
     });
+    it('should support multiple color schemes', () => {
+        const subject = (
+            <ThemeProvider theme={RootTheme}>
+                <div>
+                    <Skeleton colorStart="accent.dark" colorEnd="accent.light">
+                        Apple
+                    </Skeleton>
+                    <Skeleton colorStart="accent.dark" colorEnd="accent.light">
+                        Apple
+                    </Skeleton>
+                    <Skeleton
+                        colorStart="secondary.dark"
+                        colorEnd="secondary.light"
+                    >
+                        Banana
+                    </Skeleton>
+                </div>
+            </ThemeProvider>
+        );
+
+        const tree = renderer.create(subject).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/src/Skeleton/Skeleton.component.tsx
+++ b/src/Skeleton/Skeleton.component.tsx
@@ -101,6 +101,9 @@ export const Skeleton = ({
     children,
     display,
     textLength,
+    // This is the unicode block character that put together looks like one
+    // long bar. There are shorter and taller characters that could be used
+    // or a fatter or thinner bar.
     textChar = '▆',
     // This is the conversion from block width to the average width of
     // a normal distribution of letters. We came up with it by eyeballing it

--- a/src/Skeleton/Skeleton.stories.tsx
+++ b/src/Skeleton/Skeleton.stories.tsx
@@ -101,6 +101,10 @@ storiesOf('Components/Skeleton', module)
                         <Skeleton
                             loading={loading}
                             textLength={textLength}
+                            blockRatio={
+                                parseFloat(text('blockRatio', '')) || undefined
+                            }
+                            textChar={text('textChar', '') || undefined}
                             colorStart={text('colorStart', '') || undefined}
                             colorEnd={text('colorEnd', '') || undefined}
                         >
@@ -132,8 +136,46 @@ storiesOf('Components/Skeleton', module)
                         textLength={
                             parseInt(text('textLength', ''), 10) || undefined
                         }
+                        variant={text('variant', 'base') || undefined}
                         colorStart={text('colorStart', '') || undefined}
                         colorEnd={text('colorEnd', '') || undefined}
+                    />
+                </StyledStory>
+            </ThemeProvider>
+        );
+    })
+    .add('Multiple Colors', () => {
+        const loading = boolean('loading', true);
+
+        return (
+            <ThemeProvider theme={RootTheme}>
+                <StyledStory>
+                    <Skeleton
+                        loading={loading}
+                        textLength={200}
+                        colorStart={text('A: colorStart', '') || undefined}
+                        colorEnd={text('A: colorEnd', '') || undefined}
+                    />
+                    <Skeleton
+                        loading={loading}
+                        textLength={200}
+                        colorStart={
+                            text('B: colorStart', 'accent.light') || undefined
+                        }
+                        colorEnd={
+                            text('B: colorEnd', 'accent.dark') || undefined
+                        }
+                    />
+                    <Skeleton
+                        loading={loading}
+                        textLength={200}
+                        colorStart={
+                            text('C: colorStart', 'secondary.light') ||
+                            undefined
+                        }
+                        colorEnd={
+                            text('C: colorEnd', 'secondary.dark') || undefined
+                        }
                     />
                 </StyledStory>
             </ThemeProvider>

--- a/src/Skeleton/__snapshots__/Skeleton.component.spec.tsx.snap
+++ b/src/Skeleton/__snapshots__/Skeleton.component.spec.tsx.snap
@@ -6,8 +6,8 @@ exports[`Component: Skeleton should be defined. 1`] = `
   display: inline-block;
   pointer-events: none;
   background: #E7E7E7;
-  -webkit-animation: background-change 2s ease-in-out infinite;
-  animation: background-change 2s ease-in-out infinite;
+  -webkit-animation: fLEqvv 2s ease-in-out infinite;
+  animation: fLEqvv 2s ease-in-out infinite;
 }
 
 .c0.c0 * {
@@ -17,6 +17,7 @@ exports[`Component: Skeleton should be defined. 1`] = `
 
 <div
   className="c0 anchor-skeleton"
+  display="inline-block"
 />
 `;
 
@@ -32,14 +33,56 @@ exports[`Component: Skeleton should render in textOnly mode when given only text
   display: inherit;
   word-break: break-all;
   color: #E7E7E7;
-  -webkit-animation: color-change 2s ease-in-out infinite;
-  animation: color-change 2s ease-in-out infinite;
+  -webkit-animation: gXgMws 2s ease-in-out infinite;
+  animation: gXgMws 2s ease-in-out infinite;
 }
 
 <div
   className="c0 anchor-skeleton"
+  display="inherit"
 >
   ▆▆▆▆▆▆▆▆▆▆▆▆
+</div>
+`;
+
+exports[`Component: Skeleton should support multiple color schemes 1`] = `
+.c0 {
+  box-sizing: border-box;
+  display: inherit;
+  word-break: break-all;
+  color: #0074A6;
+  -webkit-animation: gVOVAL 2s ease-in-out infinite;
+  animation: gVOVAL 2s ease-in-out infinite;
+}
+
+.c1 {
+  box-sizing: border-box;
+  display: inherit;
+  word-break: break-all;
+  color: #268068;
+  -webkit-animation: gsfEtd 2s ease-in-out infinite;
+  animation: gsfEtd 2s ease-in-out infinite;
+}
+
+<div>
+  <div
+    className="c0 anchor-skeleton"
+    display="inherit"
+  >
+    ▆▆▆
+  </div>
+  <div
+    className="c0 anchor-skeleton"
+    display="inherit"
+  >
+    ▆▆▆
+  </div>
+  <div
+    className="c1 anchor-skeleton"
+    display="inherit"
+  >
+    ▆▆▆
+  </div>
 </div>
 `;
 
@@ -49,8 +92,8 @@ exports[`Component: Skeleton should wrap over nontext children and hide them 1`]
   display: inline-block;
   pointer-events: none;
   background: #E7E7E7;
-  -webkit-animation: background-change 2s ease-in-out infinite;
-  animation: background-change 2s ease-in-out infinite;
+  -webkit-animation: fLEqvv 2s ease-in-out infinite;
+  animation: fLEqvv 2s ease-in-out infinite;
 }
 
 .c0.c0 * {
@@ -60,6 +103,7 @@ exports[`Component: Skeleton should wrap over nontext children and hide them 1`]
 
 <div
   className="c0 anchor-skeleton"
+  display="inline-block"
 >
   <div>
     hide me!

--- a/src/Skeleton/index.ts
+++ b/src/Skeleton/index.ts
@@ -1,1 +1,1 @@
-export { Skeleton } from './Skeleton.component';
+export { Skeleton, SKELETON_KEY, SKELETON_THEME } from './Skeleton.component';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,6 +3,7 @@ import { typography } from './typography.theme';
 import { ColorsTheme } from './colors.theme';
 
 import { BUTTON_KEY, BUTTON_THEME } from '../Button';
+import { SKELETON_KEY, SKELETON_THEME } from '../Skeleton';
 import { INPUT_KEY, INPUT_THEME } from '../Form/Input/utils';
 
 export const RootTheme = {
@@ -34,8 +35,5 @@ export const RootTheme = {
         dark: `thin solid ${ColorsTheme.borders.dark}`,
     },
 
-    skeleton: {
-        colorStart: '#E7E7E7',
-        colorEnd: '#D3D3D3',
-    },
+    [SKELETON_KEY]: SKELETON_THEME,
 };

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -8,6 +8,9 @@ declare module '@xstyled/styled-components' {
         ThemedCssFunction,
         DefaultTheme,
         StyledInterface,
+        CSSKeyframes,
+        SimpleInterpolation,
+        Keyframes,
     } from 'styled-components';
     export {
         StyledInterface,
@@ -23,6 +26,11 @@ declare module '@xstyled/styled-components' {
     export const ThemeProvider: any;
     export const css: ThemedCssFunction<DefaultTheme>;
     export const withTheme: any;
+
+    export const keyframes: (
+        strings: TemplateStringsArray | CSSKeyframes,
+        ...interpolations: SimpleInterpolation[]
+    ) => Keyframes;
 
     export const up: (breakpoint: string, styles: any) => any;
     export const down: (breakpoint: string, styles: any) => any;

--- a/src/utils/themeMerge/themeMerge.spec.tsx
+++ b/src/utils/themeMerge/themeMerge.spec.tsx
@@ -86,9 +86,9 @@ describe('theme: themeMerge()', () => {
     });
 
     it('should not mutate RootTheme', () => {
-        subject.skeleton['colorStart'] = '#00ff00';
-        expect(RootTheme.skeleton['colorStart']).toBe('#E7E7E7');
-        expect(subject.skeleton['colorStart']).toBe('#00ff00');
+        subject.skeleton.variants.base['colorStart'] = '#00ff00';
+        expect(RootTheme.skeleton.variants.base['colorStart']).toBe('#E7E7E7');
+        expect(subject.skeleton.variants.base['colorStart']).toBe('#00ff00');
     });
 
     it('should overwrite RootTheme values with new values', () => {

--- a/src/utils/themeMerge/themeMerge.ts
+++ b/src/utils/themeMerge/themeMerge.ts
@@ -22,7 +22,7 @@ export type ThemeType = {
     inputs: object;
     colors: object;
     borders: object;
-    skeleton: object;
+    skeleton: any;
 };
 
 // Can't really be 100% sure what data will be as it is cloned, hence :any


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Static keyframe names didn't play nice with multiple different color schemes existing at the same time. This switches it to use the styled-components `keyframes` api to support multiple different color schemes, and also enables skeleton variants.