### PR TITLE
fix: add Box and useTheme to typings

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -26,6 +26,8 @@ declare module '@xstyled/styled-components' {
     export const ThemeProvider: any;
     export const css: ThemedCssFunction<DefaultTheme>;
     export const withTheme: any;
+    export const Box: any;
+    export const useTheme: any;
 
     export const keyframes: (
         strings: TemplateStringsArray | CSSKeyframes,


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [ ] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

It looks like Juice is getting its typings for xstyled from anchor. We would like to add `Box` and `useTheme` to the typings file.
