### PR TITLE
Fix circular dep error

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "license": "UNLICENSED",
   "types": "./ts/index.d.ts",
   "peerDependencies": {
-    "styled-components": "^4.4.0 || ^5.0.0",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.4.0 || ^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
@@ -84,7 +84,7 @@
     "@types/react-color": "^3.0.1",
     "@types/react-responsive": "^8.0.2",
     "@types/react-test-renderer": "^16.0.3",
-    "@types/styled-components": "^4.1.12",
+    "@types/styled-components": "^5.1.0",
     "@types/styled-react-modal": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/eslint-plugin-tslint": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [ ] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

The build fails with the error below.

```
[typescript] src/Button/Button.component.tsx(397,15): error TS2615: Type of property 'propTypes' circularly references itself in mapped type 'Pick<ForwardRefExoticComponent<Pick<Pick<any, Exclude<keyof ReactDefaultizedProps<StyledComponentInnerComponent<WithC>, ComponentPropsWithRef<StyledComponentInnerComponent<WithC>>>, StyledComponentInnerAttrs<...> | ... 1 more ... | StyledComponentInnerAttrs<...>> | Exclude<...> | Exclude<...> | Exclude<...>> & Parti...'.
[typescript] src/Button/Button.component.tsx(397,15): error TS2615: Type of property 'propTypes' circularly references itself in mapped type 'Pick<ForwardRefExoticComponent<Pick<Pick<any, Exclude<keyof ReactDefaultizedProps<StyledComponentInnerComponent<WithC>, ComponentPropsWithRef<StyledComponentInnerComponent<WithC>>>, any>> & Partial<...>, any> & { ...; } & WithChildrenIfReactComponentClass<...>>, "propTypes" | ... 2 more ... | "$$typeof">'.
```

It seems like it's an issue with styled components. This [suggestion](https://github.com/microsoft/TypeScript/issues/37597#issuecomment-628149946) worked for me.