### PR TITLE
fix(Dropdown): throttle touchstart and click events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -5,7 +5,13 @@ import classNames from 'classnames';
 import styled, { css } from '@xstyled/styled-components';
 import { space as spaceStyles, SpaceProps } from '@xstyled/system';
 import { fromEvent, Subscription, merge } from 'rxjs';
-import { filter, map, mapTo, distinctUntilChanged } from 'rxjs/operators';
+import {
+    filter,
+    map,
+    mapTo,
+    distinctUntilChanged,
+    throttleTime,
+} from 'rxjs/operators';
 // ANCHOR
 import { get } from '../utils/get/get';
 import { Position } from '../utils/position/position';
@@ -140,12 +146,13 @@ export class DropDown extends React.Component<DropDownProps> {
             fromEvent(this.rootElement, 'touchstart')
         ).pipe(
             filter(() => this.state.clicked),
-            filter(({ target }) => !dropDown.contains(target))
+            filter(({ target }) => !dropDown.contains(target)),
+            throttleTime(500)
         );
         const dropDownClick$ = merge(
             fromEvent(dropDown, 'click'),
             fromEvent(dropDown, 'touchstart')
-        );
+        ).pipe(throttleTime(500));
         const escapeKey$ = fromEvent(this.rootElement, 'keyup').pipe(
             filter(() => this.state.clicked || this.state.hovered),
             filter((keyEvent: KeyboardEvent) => keyEvent.key === 'Escape')

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -133,7 +133,7 @@ storiesOf('Components/DropDown', module)
                                 trigger={select<Trigger>(
                                     'trigger',
                                     ['click', 'hover', 'both'],
-                                    'hover'
+                                    'click'
                                 )}
                                 showArrow={boolean('showArrow', true)}
                                 shadow={text('shadow', '') || undefined}

--- a/src/Table/Table.component.tsx
+++ b/src/Table/Table.component.tsx
@@ -59,13 +59,14 @@ interface TableProps
         FontWeightProps,
         BorderRadiusProps,
         BorderProps,
-        WidthProps,
         MaxWidthProps,
         MinWidthProps,
         SpaceProps {
     borderRadius?: string;
     background?: string;
     altBackground?: string;
+    width?: any;
+    height?: any;
     size?: string;
 }
 
@@ -204,12 +205,12 @@ interface TableCellProps
         FontSizeProps,
         FontWeightProps,
         TextAlignProps,
-        WidthProps,
         MaxWidthProps,
         MinWidthProps,
-        HeightProps,
         SpaceProps {
     align?: 'center' | 'left' | 'right';
+    height?: any;
+    width?: any;
 }
 
 const StyledTd = styled('td')<TableCellProps>`


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Fixes touchstart and click events causing double click of dropdown for mobile devices.
