### PR TITLE
fix: fixes a few misc. problems with AutoComplete and updates the docs

### DIFF
--- a/docs/src/components/AutoCompleteExample/CustomResults.component.tsx
+++ b/docs/src/components/AutoCompleteExample/CustomResults.component.tsx
@@ -1,37 +1,50 @@
 import * as React from 'react';
 import { ListItem, Check, Typography } from '@retailmenot/anchor';
 
-interface Values {
-    [key: string]: any;
+type Value = {
+    active: boolean;
+    id: string;
+    key: string;
+    label: string;
+    onMouseOver: (event?: React.MouseEvent) => void;
+    onSelect: (event?: React.FocusEvent) => void;
+    [key: string]: any; // Value also contains any additional custom fields passed via the dataSource prop
 }
 
 interface CustomResultsProps {
     index: number;
     currentIndex: number;
     label: string;
-    value?: Values;
+    value: Value;
 }
 
 export const CustomResults = ({
     index,
     currentIndex,
-    label,
-    value,
-}: CustomResultsProps) => {
-    const isLink = value ? value.isLink : false;
-
-    return isLink ? (
+    value: {
+        active,
+        id,
+        isLink, // custom field from datasource
+        key,
+        label,
+        onMouseOver,
+        onSelect,
+    },
+}: CustomResultsProps) => isLink ? (
         <ListItem
-            key={index}
-            active={index === currentIndex}
+            key={key}
+            active={active}
+            onMouseOver={onMouseOver}
             onSelect={() => {
                 window.open('http://www.google.com', '_blank');
             }}
             prefix={<Check />}
         >
-            <Typography pl="2">Link: {label}</Typography>
+            <Typography pl="2" weight={600}>{label}</Typography>
         </ListItem>
     ) : (
-        <ListItem active={index === currentIndex}>{label}</ListItem>
+        <ListItem active={active} key={key} onSelect={onSelect} onMouseOver={onMouseOver}>
+            <Typography weight={600} mr="2">{label}</Typography>
+            (active: {active.toString()}, currentIndex: {currentIndex}, id: {id}, key: {key} index: {index})
+        </ListItem>
     );
-};

--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -159,7 +159,7 @@ props.
                 id: 'list-item-1',
                 listItemType: 'title',
             },
-            { label: 'Item 2', id: 'list-item-2', isLink: true, },
+            { label: 'Link: Item 2', id: 'list-item-2', isLink: true, },
             { label: 'Item 3', id: 'list-item-3', },
             { label: 'Item 4', id: 'list-item-4', },
         ]}

--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -22,6 +22,7 @@ property. This is an array of strings or objects with a **label** property that 
 ```tsx live hideTitle
 <div style={{ padding: '2rem 1rem' }}>
     <AutoComplete
+        browserAutoComplete={false}
         dataSource={[
             'Result 1',
             'Result 2',
@@ -45,6 +46,7 @@ tells the <Link to="/components/list/">`List`</Link> component what child node t
 ```jsx live
 <div style={{ padding: '2rem 1rem' }}>
     <AutoComplete
+        browserAutoComplete={false}
         placeholder="Search here..."
         prefix={<Search color="text.placeholder" />}
         dataSource={[
@@ -88,44 +90,60 @@ to display the possible results. This is done by passing an uninstantiated compo
 `resultTemplate` prop. `AutoComplete` will then use this template for each item rendered to the
 list of results.
 
-In the below example, our template checks to see if the `isLink` property exists as part of the
-`value` object. If it does and is truthy then it will render a `ListItem` component with different
-settings.
+<br />
 
 ###### CustomResults Component
 ```jsx hideTitle
 import * as React from 'react';
 import { ListItem, Check, Typography } from '@retailmenot/anchor';
 
-interface Values {
-    [key: string]: any;
+type Value = {
+    active: boolean;
+    id: string;
+    key: string;
+    label: string;
+    onMouseOver: (event?: React.MouseEvent) => void;
+    onSelect: (event?: React.FocusEvent) => void;
+    [key: string]: any; // Value also contains any additional custom fields passed via the dataSource prop
 }
 
 interface CustomResultsProps {
     index: number;
     currentIndex: number;
     label: string;
-    value?: Values;
+    value: Value;
 }
 
-export const CustomResults = ({ index, currentIndex, label, value }: CustomResultsProps) => {
-    const isLink = value ? value.isLink : false;
-
-    return isLink ? (
+export const CustomResults = ({
+    index,
+    currentIndex,
+    value: {
+        active,
+        id,
+        isLink, // custom field from datasource
+        key,
+        label,
+        onMouseOver,
+        onSelect,
+    },
+}: CustomResultsProps) => isLink ? (
         <ListItem
-            key={index}
-            active={index === currentIndex}
+            active={active}
+            key={key}
+            onMouseOver={onMouseOver}
             onSelect={() => {
                 window.open('http://www.google.com', '_blank');
             }}
             prefix={<Check />}
         >
-            <Typography pl="2">Link: {label}</Typography>
+            <Typography pl="2" weight={600}>{label}</Typography>
         </ListItem>
     ) : (
-        <ListItem active={index === currentIndex}>{label}</ListItem>
+        <ListItem active={active} key={key} onSelect={onSelect} onMouseOver={onMouseOver}>
+            <Typography weight={600} mr="2">{label}</Typography>
+            (active: {active.toString()}, currentIndex: {currentIndex}, id: {id}, key: {key} index: {index})
+        </ListItem>
     );
-};
 ```
 
 Now it's just a matter of passing our `CustomResults` component to the `resultTemplate` template
@@ -134,16 +152,16 @@ props.
 ```jsx live
 <div style={{ padding: '2rem 1rem' }}>
     <AutoComplete
+        browserAutoComplete={false}
         dataSource={[
             {
-                label: 'A Custom Results Template',
-                id: 1,
+                label: 'Item 1',
+                id: 'list-item-1',
                 listItemType: 'title',
             },
-            { label: 'Item 1', id: 2, someBoolean: true, isLink:true },
-            { label: 'Item 3', id: 3, someBoolean: true },
-            { label: 'Item 4', id: 4, someBoolean: true },
-            { label: 'Item 5', id: 5, someBoolean: true },
+            { label: 'Item 2', id: 'list-item-2', isLink: true, },
+            { label: 'Item 3', id: 'list-item-3', },
+            { label: 'Item 4', id: 'list-item-4', },
         ]}
         placeholder="Search here..."
         prefix={<Search color="text.placeholder" />}
@@ -154,7 +172,11 @@ props.
 
 <br />
 
-## API
+## API's
+
+---
+
+### AutoComplete
 
 <ApiTable data={[
     {
@@ -278,6 +300,78 @@ props.
         property: 'value',
         description: `The initial value of the <pre>AutoComplete</pre>.`,
         type: 'any',
+    },
+]} />
+
+---
+
+### Custom Results Template
+
+These are the props that are made available to a custom results template.
+
+<ApiTable data={[
+    {
+        property: 'index',
+        description: `The numeric index of the item in the passed <pre>dataSource</pre>. Starts at <pre>0</pre>.`,
+        type: 'number',
+    },
+    {
+        property: 'currentIndex',
+        description: `The current index of whatever item is selected.`,
+        type: 'number',
+    },
+    {
+        property: 'label',
+        description: `The passed <pre>label</pre> key for the given item in the <pre>dataSource</pre>.`,
+        type: 'number',
+    },
+    {
+        property: 'value',
+        description: `An object containing many generated values and events for the given item in the
+            <pre>dataSource</pre>. This is further detailed below.`,
+        type: 'object',
+    },
+]} />
+
+These are the properties of the `value` prop noted in the table above. Note that any custom fields in
+the `dataSource` will also be made available in this object.
+
+<ApiTable data={[
+    {
+        property: 'active',
+        description: `Whether or not the given rendered item currently is being moused over.`,
+        type: 'boolean',
+    },
+    {
+        property: 'id',
+        description: `The passed <pre>id</pre> for the given item in the <pre>dataSource</pre>.`,
+        type: 'string',
+    },
+    {
+        property: 'key',
+        description: `A unique generated key for the given item in the <pre>dataSource</pre>.`,
+        type: 'string',
+        default: 'anchor-result-[index: number]'
+    },
+    {
+        property: 'label',
+        description: `The passed <pre>label</pre> for the given item in the <pre>dataSource</pre>.
+            This is the same value as the <pre>label</pre> prop in the above table.`,
+        type: 'string',
+    },
+    {
+        property: 'onMouseOver',
+        description: `A passed event from <pre>AutoComplete</pre> that updates the <pre>active</pre>
+            and <pre>currentIndex</pre> values as items are moused over.`,
+        type: 'event',
+    },
+    {
+        property: 'onSelect',
+        description: `A passed event from <pre>AutoComplete</pre> that closes the dropdown once an
+            item has been selected, populates the <pre>AutoComplete</pre> input field with the
+            <pre>label</pre>, and emits the event and item data to <pre>AutoComplete</pre>'s own
+            <pre>onSelect</pre> event.`,
+        type: 'event',
     },
 ]} />
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "babel-preset-env": "^1.7.0",
     "chalk": "^2.4.2",
     "concurrently": "^5.0.2",
+    "csstype": "~2.6.10",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.0",

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -130,7 +130,7 @@ export const AutoComplete = ({
     ...props
 }: AutoCompleteProps) => {
     // Flag for autocomplete focus
-    const [isFocused, setIsFocused] = useState<boolean>(false);
+    const [isFocused, setIsFocused] = useState<boolean>(autoFocus);
     // The current search term
     const [term, setTerm] = useState<string>(value ? `${value}` : '');
     const autoFocusRef = useRef<HTMLDivElement>(null);
@@ -154,9 +154,11 @@ export const AutoComplete = ({
         rootElement = autoFocusRef.current
             ? autoFocusRef.current.getRootNode()
             : null;
+
         if (rootElement) {
             rootElement.addEventListener('click', handleOutsideClick);
         }
+
         return () =>
             rootElement.removeEventListener('click', handleOutsideClick);
     }, [inputRef, isFocused]);

--- a/src/AutoComplete/AutoComplete.stories.tsx
+++ b/src/AutoComplete/AutoComplete.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 // STORYBOOK
 import { storiesOf } from '@storybook/react';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select as selectKnob } from '@storybook/addon-knobs';
 // VENDOR
 import styled, { ThemeProvider } from '@xstyled/styled-components';
 // COMPONENTS
@@ -45,16 +45,19 @@ const StateBasedAutoCompleteStory = () => {
             <StyledStory>
                 <div>
                     <div>
-                        <Typography as="h1">AutoComplete 1</Typography>
+                        <Typography as="h1">AutoComplete 1 with autoFocus</Typography>
                         <br />
                         <AutoComplete
+                            autoFocus={true}
+                            browserAutoComplete={false}
+                            dataSource={tempData}
                             debug={boolean('debug', false)}
-                            placeholder="Search here..."
-                            onFilter={(newTerm: any) => {
+                            onFilter={(newTerm: any): void => {
                                 setTempData(tempDataStringSource(newTerm));
                             }}
+                            placeholder="Search here..."
                             prefix={<Search color="borders.base" />}
-                            dataSource={tempData}
+                            size={selectKnob('size', ['sm', 'md', 'lg'], 'lg')}
                         />
                     </div>
                 </div>
@@ -63,8 +66,9 @@ const StateBasedAutoCompleteStory = () => {
     );
 };
 
-const CustomResult = ({ index, currentIndex, label }: any) => {
+const CustomResult = ({ index, currentIndex, label, value }: any) => {
     const isLink = index === 2;
+
     return isLink ? (
         <Item
             key={index}
@@ -72,11 +76,12 @@ const CustomResult = ({ index, currentIndex, label }: any) => {
             onSelect={() => {
                 window.open('http://www.google.com', '_blank');
             }}
+            {...value}
         >
             Link: {label}
         </Item>
     ) : (
-        <Item active={index === currentIndex}>{label}</Item>
+        <Item active={index === currentIndex} {...value}>{label}</Item>
     );
 };
 

--- a/src/AutoComplete/__snapshots__/AutoComplete.component.spec.tsx.snap
+++ b/src/AutoComplete/__snapshots__/AutoComplete.component.spec.tsx.snap
@@ -57,8 +57,9 @@ exports[`Component: AutoComplete should be defined 1`] = `
 }
 
 .c1 input {
-  height: 1rem;
+  height: 1.5rem;
   font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .c3 {
@@ -237,8 +238,9 @@ exports[`Component: AutoComplete should render with a shadow 1`] = `
 }
 
 .c1 input {
-  height: 1rem;
+  height: 1.5rem;
   font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .c3 {
@@ -417,8 +419,9 @@ exports[`Component: AutoComplete should render with a suffix and prefix 1`] = `
 }
 
 .c1 input {
-  height: 1rem;
+  height: 1.5rem;
   font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .c3 {
@@ -606,8 +609,9 @@ exports[`Component: AutoComplete should render without a border 1`] = `
 }
 
 .c1 input {
-  height: 1rem;
+  height: 1.5rem;
   font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .c3 {

--- a/src/Form/Input/__snapshots__/Input.component.spec.tsx.snap
+++ b/src/Form/Input/__snapshots__/Input.component.spec.tsx.snap
@@ -59,6 +59,7 @@ exports[`Component: Form/Input should be defined 1`] = `
 .c0 input {
   height: 1rem;
   font-size: 0.875rem;
+  line-height: 1rem;
 }
 
 .c2 {

--- a/src/Form/Input/utils.ts
+++ b/src/Form/Input/utils.ts
@@ -7,6 +7,7 @@ export const INPUT_THEME = {
             input: {
                 height: '1rem',
                 fontSize: '0.875rem',
+                lineHeight: '1rem',
             },
         },
         md: {
@@ -16,6 +17,7 @@ export const INPUT_THEME = {
             input: {
                 height: '1rem',
                 fontSize: '0.875rem',
+                lineHeight: '1rem',
             },
         },
         lg: {
@@ -23,8 +25,9 @@ export const INPUT_THEME = {
             padding: '0.25rem',
 
             input: {
-                height: '1rem',
+                height: '1.5rem',
                 fontSize: '1rem',
+                lineHeight: '1.5rem',
             },
         },
     },

--- a/src/Pagination/Goto/__snapshots__/Goto.component.spec.tsx.snap
+++ b/src/Pagination/Goto/__snapshots__/Goto.component.spec.tsx.snap
@@ -59,6 +59,7 @@ exports[`Component: Goto should be defined. 1`] = `
 .c1 input {
   height: 1rem;
   font-size: 0.875rem;
+  line-height: 1rem;
 }
 
 .c3 {


### PR DESCRIPTION
fix(AutoComplete): isFocused now receives its initial value from autoFocus prop

fix(AutoComplete): custom result story now spreads value to attach events

fix(AutoComplete): added size knob for StateBasedAutoCompleteStory

fix(Input): line heights given to inputs to fix cutoff of text

docs(autocomplete): better documentation on custom result templates

**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**
