### PR TITLE
feat(Dropdown): add controlled state option

### DIFF
--- a/docs/src/components/Navigation/SectionNavigation/SectionNavigation.component.tsx
+++ b/docs/src/components/Navigation/SectionNavigation/SectionNavigation.component.tsx
@@ -13,6 +13,9 @@ import {
 import { AddLocation } from '../AddLocation';
 
 const StyledCollapseGroup = styled(CollapseGroup)`
+    button {
+        align-items: center;
+    }
     li a {
         text-decoration: none;
 

--- a/docs/src/pages/components/dropdown.mdx
+++ b/docs/src/pages/components/dropdown.mdx
@@ -185,6 +185,12 @@ default `click` trigger behavior:
         type: 'boolean',
     },
     {
+        property: 'open',
+        description: `If defined, forces the <pre>DropDown</pre> overlay to be open or closed.
+            Overrides the default trigger behavior.`,
+        type: 'boolean',
+    },
+    {
         property: 'onEscapeKey',
         description: `An event handler for the escape key being pressed. Only fires when dropdown is open.`,
         type: '(event?: any) => any',

--- a/docs/src/pages/components/dropdown.mdx
+++ b/docs/src/pages/components/dropdown.mdx
@@ -102,7 +102,35 @@ together with `DropDown`!
 </DropDown>
 ```
 
+### Controlled State
+
+If you need greater control over when your dropdown displays, you can opt into controlling it
+manually with the `open` prop. Using it will ignore the internal `trigger` prop behavior. With
+the help of the `onClick`, `onEscapeKey` and `onOutsideClick` handlers, we can recreate the
+default `click` trigger behavior:
+
+
+```tsx live hideTitle
+<Component initialState={{ isOpen: false }}>
+    {({ state, setState }) =>
+        <DropDown
+            open={state.isOpen}
+            onClick={() => setState({ isOpen: !state.isOpen })}
+            onEscapeKey={() => setState({ isOpen: false })}
+            onOutsideClick={() => setState({ isOpen: false })}
+            overlay={<MyList />}
+        >
+            <MouseOverMe color="white">
+                I'm manually controlled!
+            </MouseOverMe>
+        </DropDown>
+    }
+</Component>
+```
+
 ---
+
+
 
 ## API
 
@@ -157,6 +185,22 @@ together with `DropDown`!
         type: 'boolean',
     },
     {
+        property: 'onEscapeKey',
+        description: `An event handler for the escape key being pressed. Only fires when dropdown is open.`,
+        type: '(event?: any) => any',
+    },
+    {
+        property: 'onOutsideClick',
+        description: `An event handler for when the user clicks outside the dropdown. Only fires when dropdown is open.`,
+        type: '(event?: any) => any',
+    },
+    {
+        property: 'onTriggered',
+        description: `An event handler that is fired whenever the dropdown opens or closes. Only applies to
+            uncontrolled triggers.`,
+        type: '(state: boolean, trigger?: string) => void',
+    },
+    {
         property: 'overlay',
         description: `The content that will be displayed when the child node is hovered
             over. This can be a single React element, or an array of React elements.`,
@@ -168,18 +212,18 @@ together with `DropDown`!
             document`,
         type: <FormatTypes
                 data={[
-                    'topStart',
                     'top',
+                    'topStart',
                     'topEnd',
-                    'rightStart',
                     'right',
+                    'rightStart',
                     'rightEnd',
-                    'bottomEnd',
                     'bottom',
                     'bottomStart',
-                    'leftEnd',
+                    'bottomEnd',
                     'left',
                     'leftStart',
+                    'leftEnd',
                 ]} />,
         default: 'bottom'
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/DropDown/DropDown.component.tsx
+++ b/src/DropDown/DropDown.component.tsx
@@ -156,7 +156,10 @@ export class DropDown extends React.Component<DropDownProps> {
         });
 
         // Dropdown Instance
-        this.rootElement = dropDown ? dropDown.getRootNode() : null;
+        this.rootElement =
+            dropDown && dropDown.getRootNode
+                ? dropDown.getRootNode()
+                : document;
 
         const outsideClick$ = merge(
             fromEvent(this.rootElement, 'click'),

--- a/src/DropDown/DropDown.stories.tsx
+++ b/src/DropDown/DropDown.stories.tsx
@@ -29,6 +29,21 @@ const listItemArray = [
     { key: 5, label: 'List Item 5' },
 ];
 
+const positions: Position[] = [
+    'topStart',
+    'top',
+    'topEnd',
+    'rightStart',
+    'right',
+    'rightEnd',
+    'bottomStart',
+    'bottom',
+    'bottomEnd',
+    'leftStart',
+    'left',
+    'leftEnd',
+];
+
 const MockList = () => (
     <List>
         {listItemArray.map(({ key, label }: any) => (
@@ -114,20 +129,7 @@ storiesOf('Components/DropDown', module)
                                 overlay={<MockList />}
                                 position={select<Position>(
                                     'position',
-                                    [
-                                        'topStart',
-                                        'top',
-                                        'topEnd',
-                                        'rightStart',
-                                        'right',
-                                        'rightEnd',
-                                        'bottomEnd',
-                                        'bottom',
-                                        'bottomStart',
-                                        'leftEnd',
-                                        'left',
-                                        'leftStart',
-                                    ],
+                                    positions,
                                     'bottom'
                                 )}
                                 trigger={select<Trigger>(
@@ -160,30 +162,48 @@ storiesOf('Components/DropDown', module)
             </StyledStory>
         </ThemeProvider>
     ))
+    .add('Controlled Demo', () =>
+        React.createElement(() => {
+            const [isOpen, setIsOpen] = React.useState<boolean>(false);
+
+            return (
+                <ThemeProvider theme={RootTheme}>
+                    <StyledStory>
+                        <div>
+                            <Typography as="h1">DropDown</Typography>
+                            <DropDown
+                                open={isOpen}
+                                onClick={() => setIsOpen(true)}
+                                onEscapeKey={() => setIsOpen(false)}
+                                onOutsideClick={() => setIsOpen(false)}
+                                overlay={<MockList />}
+                                position={select<Position>(
+                                    'position',
+                                    positions,
+                                    'bottom'
+                                )}
+                                showArrow={boolean('showArrow', true)}
+                                spacing={text('spacing', '') || undefined}
+                                debug={boolean('Debug', false)}
+                            >
+                                <Button>
+                                    {/* Not a prop, just for testing various widths */}
+                                    {text('Text', 'Dropdown')}
+                                </Button>
+                            </DropDown>
+                        </div>
+                    </StyledStory>
+                </ThemeProvider>
+            );
+        })
+    )
     .add('Resize Demo', () => (
         <ThemeProvider theme={RootTheme}>
             <StyledStory>
                 <Typography as="h1">DropDown</Typography>
                 <DropDown
                     overlay={<MockList />}
-                    position={select<Position>(
-                        'position',
-                        [
-                            'topStart',
-                            'top',
-                            'topEnd',
-                            'rightStart',
-                            'right',
-                            'rightEnd',
-                            'bottomEnd',
-                            'bottom',
-                            'bottomStart',
-                            'leftEnd',
-                            'left',
-                            'leftStart',
-                        ],
-                        'bottom'
-                    )}
+                    position={select<Position>('position', positions, 'bottom')}
                     trigger={select<Trigger>(
                         'trigger',
                         ['click', 'hover', 'both'],

--- a/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
+++ b/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
@@ -101,17 +101,17 @@ exports[`Component: DropDown should render in the DOM 1`] = `
     width={null}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       <div>
         1
       </div>
     </div>
     <div
-      className="c4 position-arrow"
+      className="c4 anchor-position-arrow"
     />
   </div>
 </div>

--- a/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
+++ b/src/DropDown/__snapshots__/DropDown.component.spec.tsx.snap
@@ -101,17 +101,17 @@ exports[`Component: DropDown should render in the DOM 1`] = `
     width={null}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       <div>
         1
       </div>
     </div>
     <div
-      className="c4"
+      className="c4 position-arrow"
     />
   </div>
 </div>

--- a/src/PopOver/__snapshots__/PopOver.component.spec.tsx.snap
+++ b/src/PopOver/__snapshots__/PopOver.component.spec.tsx.snap
@@ -137,10 +137,10 @@ exports[`Component: PopOver should be defined. 1`] = `
     width={null}
   >
     <div
-      className="c3"
+      className="c3 position-bg"
     />
     <div
-      className="c4"
+      className="c4 position-overlay"
     >
       Hello!
     </div>

--- a/src/PopOver/__snapshots__/PopOver.component.spec.tsx.snap
+++ b/src/PopOver/__snapshots__/PopOver.component.spec.tsx.snap
@@ -137,10 +137,10 @@ exports[`Component: PopOver should be defined. 1`] = `
     width={null}
   >
     <div
-      className="c3 position-bg"
+      className="c3 anchor-position-bg"
     />
     <div
-      className="c4 position-overlay"
+      className="c4 anchor-position-overlay"
     >
       Hello!
     </div>

--- a/src/Tooltip/__snapshots__/Tooltip.component.spec.tsx.snap
+++ b/src/Tooltip/__snapshots__/Tooltip.component.spec.tsx.snap
@@ -72,10 +72,10 @@ exports[`Component: Tooltip should be defined and match its snapshot. 1`] = `
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -155,10 +155,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -238,10 +238,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 2
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -321,10 +321,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 3
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -404,10 +404,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 4
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -487,10 +487,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 5
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -570,10 +570,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 6
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -653,10 +653,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 7
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -736,10 +736,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 8
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -819,10 +819,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 9
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -902,10 +902,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -985,10 +985,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>
@@ -1068,10 +1068,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2"
+      className="c2 position-bg"
     />
     <div
-      className="c3"
+      className="c3 position-overlay"
     >
       This is a tooltip
     </div>

--- a/src/Tooltip/__snapshots__/Tooltip.component.spec.tsx.snap
+++ b/src/Tooltip/__snapshots__/Tooltip.component.spec.tsx.snap
@@ -72,10 +72,10 @@ exports[`Component: Tooltip should be defined and match its snapshot. 1`] = `
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -155,10 +155,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -238,10 +238,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 2
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -321,10 +321,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 3
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -404,10 +404,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 4
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -487,10 +487,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 5
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -570,10 +570,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 6
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -653,10 +653,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 7
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -736,10 +736,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 8
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -819,10 +819,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 9
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -902,10 +902,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -985,10 +985,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>
@@ -1068,10 +1068,10 @@ exports[`Component: Tooltip should render all the different tooltip positions. 1
     width={0}
   >
     <div
-      className="c2 position-bg"
+      className="c2 anchor-position-bg"
     />
     <div
-      className="c3 position-overlay"
+      className="c3 anchor-position-overlay"
     >
       This is a tooltip
     </div>

--- a/src/utils/PositionContainer/PositionContainer.component.tsx
+++ b/src/utils/PositionContainer/PositionContainer.component.tsx
@@ -147,12 +147,15 @@ export const PositionContainer = forwardRef(
             shadow={shadow}
             width={width}
         >
-            <Background background={background} />
+            <Background className="position-bg" background={background} />
 
-            <StyledOverlay>{children}</StyledOverlay>
+            <StyledOverlay className="position-overlay">
+                {children}
+            </StyledOverlay>
 
             {showArrow && (
                 <Arrow
+                    className="position-arrow"
                     position={position}
                     size={arrowSize}
                     indent={arrowIndent}

--- a/src/utils/PositionContainer/PositionContainer.component.tsx
+++ b/src/utils/PositionContainer/PositionContainer.component.tsx
@@ -147,15 +147,18 @@ export const PositionContainer = forwardRef(
             shadow={shadow}
             width={width}
         >
-            <Background className="position-bg" background={background} />
+            <Background
+                className="anchor-position-bg"
+                background={background}
+            />
 
-            <StyledOverlay className="position-overlay">
+            <StyledOverlay className="anchor-position-overlay">
                 {children}
             </StyledOverlay>
 
             {showArrow && (
                 <Arrow
-                    className="position-arrow"
+                    className="anchor-position-arrow"
                     position={position}
                     size={arrowSize}
                     indent={arrowIndent}

--- a/src/utils/PositionContainer/__snapshots__/PositionContainer.spec.tsx.snap
+++ b/src/utils/PositionContainer/__snapshots__/PositionContainer.spec.tsx.snap
@@ -56,10 +56,10 @@ exports[`Component: PositionContainer should be defined. 1`] = `
   width={100}
 >
   <div
-    className="c1"
+    className="c1 position-bg"
   />
   <div
-    className="c2"
+    className="c2 position-overlay"
   />
 </div>
 `;

--- a/src/utils/PositionContainer/__snapshots__/PositionContainer.spec.tsx.snap
+++ b/src/utils/PositionContainer/__snapshots__/PositionContainer.spec.tsx.snap
@@ -56,10 +56,10 @@ exports[`Component: PositionContainer should be defined. 1`] = `
   width={100}
 >
   <div
-    className="c1 position-bg"
+    className="c1 anchor-position-bg"
   />
   <div
-    className="c2 position-overlay"
+    className="c2 anchor-position-overlay"
   />
 </div>
 `;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

Allows the Dropdown component to be manually controlled via an `open` prop.