### PR TITLE
fix: autocomplete - first item active/tabbing

### DIFF
--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -154,11 +154,7 @@ props.
     <AutoComplete
         browserAutoComplete={false}
         dataSource={[
-            {
-                label: 'Item 1',
-                id: 'list-item-1',
-                listItemType: 'title',
-            },
+            { label: 'Item 1', id: 'list-item-1', },
             { label: 'Link: Item 2', id: 'list-item-2', isLink: true, },
             { label: 'Item 3', id: 'list-item-3', },
             { label: 'Item 4', id: 'list-item-4', },
@@ -183,7 +179,7 @@ props.
         property: 'browserAutoComplete',
         description: 'Enable/Disable browser auto complete for input',
         type: 'boolean',
-        default: 'true',
+        default: 'false',
     },
     {
         property: 'autoFocus',
@@ -226,6 +222,12 @@ props.
         description: `When set to true, causes the result list to remain visible even
             when <pre>AutoComplete</pre> loses focus. This can be helpful for developing custom
             styles and/or a <pre>resultTemplate</pre>`,
+        type: 'boolean',
+        default: 'false',
+    },
+    {
+        property: 'highlightFirst',
+        description: `When set to true, the first item in the result dropdown will be highlighted by default until a new item is moused over.`,
         type: 'boolean',
         default: 'false',
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/AutoComplete/AutoComplete.component.tsx
+++ b/src/AutoComplete/AutoComplete.component.tsx
@@ -32,6 +32,7 @@ interface AutoCompleteProps extends SpaceProps {
     allowClear?: boolean;
     browserAutoComplete?: boolean;
     autoFocus?: boolean;
+    highlightFirst?: boolean;
     // Visual
     background?: string;
     border?: boolean;
@@ -106,7 +107,7 @@ const StyledAutoComplete = styled('div')<StyledAutoCompleteProps>`
 
 export const AutoComplete = ({
     allowClear,
-    browserAutoComplete = true,
+    browserAutoComplete = false,
     autoFocus = false,
     background = 'white',
     border = true,
@@ -114,6 +115,7 @@ export const AutoComplete = ({
     color = 'text.light',
     dataSource = [],
     debug = false,
+    highlightFirst = false,
     inputProps,
     inputType = 'text',
     name = '',
@@ -227,9 +229,13 @@ export const AutoComplete = ({
                 onKeyDown={(event: React.KeyboardEvent) => {
                     switch (event.keyCode) {
                         case EventKeyCodes.TAB:
-                            if (!term) {
-                                break;
+                            // This should only fire if the results container exists
+                            if (isFocused && resultsRef.current) {
+                                // Update term of the autocomplete
+                                resultsRef.current.updateTerm(term);
+                                setIsFocused(false);
                             }
+                            break;
                         case EventKeyCodes.ENTER:
                             if (term) {
                                 event.preventDefault();
@@ -278,6 +284,7 @@ export const AutoComplete = ({
                     resultTemplate={resultTemplate}
                     dataSource={dataSource}
                     term={term}
+                    highlightFirst={highlightFirst}
                 />
             )}
         </StyledAutoComplete>

--- a/src/AutoComplete/AutoComplete.stories.tsx
+++ b/src/AutoComplete/AutoComplete.stories.tsx
@@ -45,13 +45,16 @@ const StateBasedAutoCompleteStory = () => {
             <StyledStory>
                 <div>
                     <div>
-                        <Typography as="h1">AutoComplete 1 with autoFocus</Typography>
+                        <Typography as="h1">
+                            AutoComplete 1 with autoFocus
+                        </Typography>
                         <br />
                         <AutoComplete
                             autoFocus={true}
                             browserAutoComplete={false}
                             dataSource={tempData}
                             debug={boolean('debug', false)}
+                            highlightFirst={true}
                             onFilter={(newTerm: any): void => {
                                 setTempData(tempDataStringSource(newTerm));
                             }}
@@ -81,7 +84,9 @@ const CustomResult = ({ index, currentIndex, label, value }: any) => {
             Link: {label}
         </Item>
     ) : (
-        <Item active={index === currentIndex} {...value}>{label}</Item>
+        <Item active={index === currentIndex} {...value}>
+            {label}
+        </Item>
     );
 };
 

--- a/src/AutoComplete/__snapshots__/AutoComplete.component.spec.tsx.snap
+++ b/src/AutoComplete/__snapshots__/AutoComplete.component.spec.tsx.snap
@@ -162,7 +162,7 @@ exports[`Component: AutoComplete should be defined 1`] = `
       >
         <input
           aria-label="auto-complete"
-          autoComplete="on"
+          autoComplete="off"
           autoFocus={false}
           className="c4"
           name="auto-complete"
@@ -344,7 +344,7 @@ exports[`Component: AutoComplete should render with a shadow 1`] = `
       >
         <input
           aria-label="auto-complete"
-          autoComplete="on"
+          autoComplete="off"
           autoFocus={false}
           className="c4"
           name="auto-complete"
@@ -529,7 +529,7 @@ exports[`Component: AutoComplete should render with a suffix and prefix 1`] = `
       >
         <input
           aria-label="auto-complete"
-          autoComplete="on"
+          autoComplete="off"
           autoFocus={false}
           className="c4"
           name="auto-complete"
@@ -714,7 +714,7 @@ exports[`Component: AutoComplete should render without a border 1`] = `
       >
         <input
           aria-label="auto-complete"
-          autoComplete="on"
+          autoComplete="off"
           autoFocus={false}
           className="c4"
           name="auto-complete"


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [ ] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [ ] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [ ] Tested my solution on Mobile & Tablet.
- [ ] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [ ] Updated snapshots for all permutations (`npm test -- -u`).
- [ ] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [ ] Created TODOs for known edge cases.
- [ ] Documented all of my changes (inline & doc site).
- [ ] Made sure that all accessibility errors are resolved.
- [ ] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [ ] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [ ] Added name to OWNERS file for all new components
- [ ] If adding a new component, add its export to the rollup config
- [ ] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

My code does...
