### PR TITLE
fix(Pagination): controlled initial value and onChange fire logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retailmenot/anchor",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "A React UI Library by RetailMeNot",
   "main": "commonjs/index.js",
   "module": "esm/index.js",

--- a/src/Pagination/Pagination.component.tsx
+++ b/src/Pagination/Pagination.component.tsx
@@ -11,6 +11,7 @@ import {
 } from '../Button/Button.component';
 import { ChevronLeft, ChevronRight, Ellipses } from '../Icon';
 import { Typography } from '../Typography';
+import { useUpdateEffect } from '../utils/useUpdateEffect/useUpdateEffect';
 
 // Constrain a value between a min and max.
 // Used primarily here to keep the current page
@@ -122,7 +123,7 @@ export const Pagination = ({
     ...props
 }: PaginationProps): React.ReactElement<PaginationProps> => {
     const [state, dispatch] = React.useReducer(reducer, {
-        current: 1,
+        current: controlledCurrent || 1,
     });
 
     // If the current page is controlled we want to
@@ -134,11 +135,11 @@ export const Pagination = ({
     const total =
         totalPages || (totalResults && Math.ceil(totalResults / pageSize)) || 1;
 
-    React.useEffect(() => {
+    useUpdateEffect(() => {
         dispatch({ type: 'totalChanged', total });
     }, [total]);
 
-    React.useEffect(() => {
+    useUpdateEffect(() => {
         if (onChange) {
             onChange(state.current);
         }

--- a/src/utils/useUpdateEffect/useUpdateEffect.ts
+++ b/src/utils/useUpdateEffect/useUpdateEffect.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-arrow-callback */
 import * as React from 'react';
 
 // useUpdateEffect is a useEffect that doesn't fire on initial render

--- a/src/utils/useUpdateEffect/useUpdateEffect.ts
+++ b/src/utils/useUpdateEffect/useUpdateEffect.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+// useUpdateEffect is a useEffect that doesn't fire on initial render
+// for detecting when values change
+// https://stackoverflow.com/a/58217148
+
+const useIsMounted = function useIsMounted() {
+    const isMounted = React.useRef(false);
+
+    React.useEffect(function setIsMounted() {
+        isMounted.current = true;
+
+        return function cleanupSetIsMounted() {
+            isMounted.current = false;
+        };
+    }, []);
+
+    return isMounted;
+};
+
+export const useUpdateEffect = function useUpdateEffect(
+    effect: () => void | (() => void),
+    dependencies: Array<any>
+): void {
+    const isMounted = useIsMounted();
+    const isInitialMount = React.useRef(true);
+
+    React.useEffect(() => {
+        let effectCleanupFunc = function noop() {};
+
+        if (isInitialMount.current) {
+            isInitialMount.current = false;
+        } else {
+            effectCleanupFunc = effect() || effectCleanupFunc;
+        }
+        return () => {
+            effectCleanupFunc();
+            if (!isMounted.current) {
+                isInitialMount.current = true;
+            }
+        };
+    }, dependencies); // eslint-disable-line react-hooks/exhaustive-deps
+};

--- a/src/utils/useUpdateEffect/useUpdateEffect.ts
+++ b/src/utils/useUpdateEffect/useUpdateEffect.ts
@@ -4,6 +4,7 @@ import * as React from 'react';
 // for detecting when values change
 // https://stackoverflow.com/a/58217148
 
+// Named functions are for stack traceability
 const useIsMounted = function useIsMounted() {
     const isMounted = React.useRef(false);
 
@@ -20,12 +21,13 @@ const useIsMounted = function useIsMounted() {
 
 export const useUpdateEffect = function useUpdateEffect(
     effect: () => void | (() => void),
-    dependencies: Array<any>
+    dependencies: any[]
 ): void {
     const isMounted = useIsMounted();
     const isInitialMount = React.useRef(true);
 
     React.useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         let effectCleanupFunc = function noop() {};
 
         if (isInitialMount.current) {
@@ -39,5 +41,5 @@ export const useUpdateEffect = function useUpdateEffect(
                 isInitialMount.current = true;
             }
         };
-    }, dependencies); // eslint-disable-line react-hooks/exhaustive-deps
+    }, dependencies);
 };


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

I have done **all** of the following:

- [x] Added a top level class to all my components `'.anchor-[COMPONENT NAME]'`.
- [x] Used [conventional commits](https://www.conventionalcommits.org) for all work.
- [x] Tested my solution on Mobile & Tablet.
- [x] Wrote [unit tests](https://jestjs.io/docs/en/getting-started) for states and all behavior (`npm test`) and passed coverage thresholds.
- [x] Updated snapshots for all permutations (`npm test -- -u`).
- [x] Accounted for hover, focus, blur, visited, & error states because they are not edge cases.
- [x] Created TODOs for known edge cases.
- [x] Documented all of my changes (inline & doc site).
- [x] Made sure that all accessibility errors are resolved.
- [x] Added [stories](https://storybook.js.org/docs/basics/introduction/) with knobs for all possible configurations.
- [x] De-linted and ran [prettier](https://github.com/prettier/prettier) (`npm run pretty`) on my code.
- [x] Added name to OWNERS file for all new components
- [x] If adding a new component, add its export to the rollup config
- [x] package.json version is bumped (if necessary)

---------
**Outline your feature or bug-fix below**

In a controlled Pagination, initial values that weren't `1` would be overridden. onChange and onTotalChange would extraneously fire on initial render. This PR fixes both of those problems.